### PR TITLE
fix: three small reported bugs (#234, #237, #238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,31 @@ env:
     valueFrom:
       secretKeyRef:
         name: oidc-client-grafana-owner-secrets
-        key: OIDC_GATEWAY_AUTH_URI
+        key: OIDC_IDP_AUTH_URI
 ```
+
+The generated secret carries these keys:
+
+| Key | Value |
+|---|---|
+| `OIDC_CLIENT_ID` | `<namespace>.<name>` |
+| `OIDC_CLIENT_SECRET` | Generated client secret |
+| `OIDC_GRANT_TYPES` | `spec.grantTypes` |
+| `OIDC_RESPONSE_TYPES` | `spec.responseTypes` |
+| `OIDC_TOKEN_ENDPOINT_AUTH_METHOD` | `spec.tokenEndpointAuthMethod` |
+| `OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG` | `spec.idTokenSignedResponseAlg` |
+| `OIDC_REDIRECT_URIS` | `spec.redirectUris` |
+| `OIDC_AVAILABLE_SCOPES` | `spec.availableScopes`, joined by `spec.availableScopesDelimiter` |
+| `OIDC_ALLOWED_GROUPS` | `spec.allowedGroups` |
+| `OIDC_ALLOWED_USERS` | `spec.allowedUsers` |
+| `OIDC_IDP_URI` | Issuer base URL |
+| `OIDC_IDP_WELL_KNOWN_URI` | Discovery document |
+| `OIDC_IDP_AUTH_URI` | Authorization endpoint |
+| `OIDC_IDP_TOKEN_URI` | Token endpoint |
+| `OIDC_IDP_USERINFO_URI` | UserInfo endpoint |
+
+List-valued keys are comma-separated, except `OIDC_AVAILABLE_SCOPES` when
+`spec.availableScopesDelimiter` says otherwise.
 
 To list applications:
 

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             - name: REDIS_URI
               valueFrom:
                 secretKeyRef:
-                  name: redis-{{ include "passmower.fullname" . }}-owner-secret
+                  name: redis-{{ include "passmower.fullname" . }}-owner-secrets
                   key: REDIS_MASTER_0_URI
             {{- else if and .Values.redis.external.enabled .Values.redis.external.secretKeyRef.name (not .Values.redis.external.host) (not .Values.redis.external.envFromSecretRef) }}
             - name: REDIS_URI

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -490,7 +490,15 @@ class Account {
                 }
                 const source = getUsernameSource()
                 if (source === 'prompt') {
-                    return await requireCustomUsername(ctx, provider, {email, githubEmails, preferredUsername, identity})
+                    // Suggest the sanitized candidate, not the raw upstream
+                    // value: an OIDC preferred_username is often an email (a UPN
+                    // on Entra ID), which breaks four of the five USERNAME_RULES,
+                    // so prefilling it raw hands the user a field they have to
+                    // clear before they can get anywhere.
+                    const candidate = sanitizeUsername(preferredUsername)
+                    return await requireCustomUsername(ctx, provider, {
+                        email, githubEmails, preferredUsername: candidate ?? preferredUsername, identity,
+                    })
                 } else if (source === 'upstream') {
                     const candidate = sanitizeUsername(preferredUsername)
                     if (candidate && isUsernameValid(candidate) && await isUsernameAvailable(ctx, candidate)) {

--- a/test/unit/chart-secret-references.test.js
+++ b/test/unit/chart-secret-references.test.js
@@ -1,0 +1,38 @@
+import {readFileSync} from 'node:fs'
+import {load} from 'js-yaml'
+import {describe, expect, it} from 'vitest'
+
+// deployment.yaml is a Go template, so it is asserted as text; values.yaml is
+// plain YAML.
+const deployment = readFileSync(
+    new URL('../../charts/passmower/templates/deployment.yaml', import.meta.url), 'utf8')
+const values = load(readFileSync(
+    new URL('../../charts/passmower/values.yaml', import.meta.url), 'utf8'))
+
+// The redis-operator derives its Secret name from the RedisClaim with a plural
+// suffix. The chart shipped the singular in the redisClaim branch while its own
+// `external` default used the plural, so `redisClaim.enabled: true` produced a
+// pod stuck in CreateContainerConfigError on a Secret nobody creates — with the
+// claim Bound and the install otherwise clean.
+describe('generated redis Secret references', () => {
+    it('uses the plural owner-secrets suffix in the redisClaim branch', () => {
+        const claimBranch = deployment.slice(
+            deployment.indexOf('.Values.redis.redisClaim.enabled'),
+            deployment.indexOf('.Values.redis.external.enabled'),
+        )
+
+        expect(claimBranch).toContain('-owner-secrets')
+        expect(claimBranch).not.toMatch(/-owner-secret\b(?!s)/)
+    })
+
+    it('agrees with the suffix the external default documents', () => {
+        // Both branches point at the same operator-managed Secret, so a
+        // divergence between them means one of the two cannot resolve.
+        expect(values.redis.external.secretKeyRef.name).toMatch(/-owner-secrets$/)
+    })
+
+    it('reads the same key on both paths', () => {
+        expect(values.redis.external.secretKeyRef.key).toBe('REDIS_MASTER_0_URI')
+        expect(deployment).toContain('key: REDIS_MASTER_0_URI')
+    })
+})

--- a/test/unit/readme-secret-keys.test.js
+++ b/test/unit/readme-secret-keys.test.js
@@ -1,0 +1,39 @@
+import {readFileSync} from 'node:fs'
+import {describe, expect, it} from 'vitest'
+import * as constants from '../../src/utils/kubernetes/kube-constants.js'
+
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8')
+
+// Every OIDC_* key the generated client Secret carries, from the constants the
+// model writes it with.
+const secretKeys = new Set(
+    Object.entries(constants)
+        .filter(([name, value]) => /^OIDCClientSecret.*Key$/.test(name) && typeof value === 'string')
+        .map(([, value]) => value)
+)
+
+// The README is what a new integration is written from, and it named
+// OIDC_GATEWAY_AUTH_URI — a 1.x key that no longer exists — long after the
+// rename to OIDC_IDP_*. Copying it verbatim yields
+// CreateContainerConfigError on a key that is not in the Secret.
+describe('README references only keys the generated Secret carries', () => {
+    it('documents no unknown OIDC_* secret key', () => {
+        const referenced = [...readme.matchAll(/^\s*(?:key: |\| `)(OIDC_[A-Z0-9_]+)/gm)]
+            .map(match => match[1])
+
+        expect(referenced.length).toBeGreaterThan(0)
+        expect([...new Set(referenced.filter(key => !secretKeys.has(key)))]).toEqual([])
+    })
+
+    it('carries no leftover 1.x OIDC_GATEWAY_* names', () => {
+        expect(readme).not.toContain('OIDC_GATEWAY')
+    })
+
+    it('enumerates the full key set', () => {
+        // The README used to show three of the fifteen with nowhere listing the
+        // rest; keep the table complete as keys are added.
+        for (const key of secretKeys) {
+            expect(readme).toContain(`\`${key}\``)
+        }
+    })
+})

--- a/test/unit/username-prompt-prefill.test.js
+++ b/test/unit/username-prompt-prefill.test.js
@@ -1,0 +1,91 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// getUsernameSource memoises in module scope, so each case re-imports Account
+// under a stubbed environment (same approach as username-source.test.js).
+async function accountUnder(source) {
+    vi.resetModules()
+    vi.stubEnv('USERNAME_SOURCE', source)
+    vi.stubEnv('ENROLL_USERS', 'true')
+    return (await import('../../src/models/account.js')).default
+}
+
+const providerStub = () => ({
+    interactionDetails: vi.fn().mockResolvedValue({result: {}}),
+    interactionResult: vi.fn().mockResolvedValue(undefined),
+})
+
+// No existing user, so enrollment decides the username.
+const ctxStub = () => ({
+    req: {}, res: {}, headers: {},
+    kubeOIDCUserService: {
+        listUsers: vi.fn().mockResolvedValue([]),
+        findUserByEmails: vi.fn().mockResolvedValue(undefined),
+    },
+})
+
+// What the enter-username form is prefilled with: requireCustomUsername stashes
+// preferredUsername in the interaction result, and enter-username.ejs renders it
+// as the input's value.
+const prefilledWith = (provider) => provider.interactionResult.mock.calls[0][2].preferredUsername
+
+beforeEach(() => {
+    globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('USERNAME_SOURCE=prompt prefill', () => {
+    it('suggests a sanitized username for an email-shaped upstream value', async () => {
+        const Account = await accountUnder('prompt')
+        const provider = providerStub()
+
+        await Account.createOrUpdateByEmails(
+            ctxStub(), provider, 'alice.smith@example.com', undefined, undefined,
+            'alice.smith@example.com', {},
+        )
+
+        // Not the raw UPN, which breaks the length, alphanumeric, lowercase and
+        // leading-letter rules and so could never be submitted as-is.
+        expect(prefilledWith(provider)).toBe('alicesmith')
+    })
+
+    it('leaves an already-valid upstream username alone', async () => {
+        const Account = await accountUnder('prompt')
+        const provider = providerStub()
+
+        await Account.createOrUpdateByEmails(
+            ctxStub(), provider, 'alice@example.com', undefined, undefined, 'alice', {},
+        )
+
+        expect(prefilledWith(provider)).toBe('alice')
+    })
+
+    it('falls back to the raw value when nothing usable survives sanitizing', async () => {
+        const Account = await accountUnder('prompt')
+        const provider = providerStub()
+
+        // Sanitizing yields null here (all digits are stripped as a leading run),
+        // so there is no better suggestion to offer than what upstream said.
+        await Account.createOrUpdateByEmails(
+            ctxStub(), provider, '123@example.com', undefined, undefined, '123', {},
+        )
+
+        expect(prefilledWith(provider)).toBe('123')
+    })
+
+    it('matches what the upstream source already does when it cannot use the value', async () => {
+        // USERNAME_SOURCE=upstream has always prefilled the sanitized candidate;
+        // prompt now agrees, so the two paths suggest the same thing.
+        const Account = await accountUnder('upstream')
+        const provider = providerStub()
+        const ctx = ctxStub()
+        // Taken, so upstream cannot use it and falls through to the prompt form.
+        ctx.kubeOIDCUserService.findUser = vi.fn().mockResolvedValue({accountId: 'alicesmith'})
+
+        await Account.createOrUpdateByEmails(
+            ctx, provider, 'alice.smith@example.com', undefined, undefined,
+            'alice.smith@example.com', {},
+        )
+
+        expect(prefilledWith(provider)).toBe('alicesmith')
+    })
+})


### PR DESCRIPTION
Fixes #234, #237 and #238 (all need closing by hand — PRs into `develop` don't auto-close). Three independent one-liners, grouped because each is a single line of product change plus the test that would have caught it. #235 and #236 are left alone: both need a design decision.

I verified each report against the code before touching anything; all three were accurate, line numbers included.

## #234 — `redisClaim.enabled: true` could never start

`deployment.yaml:143` referenced `redis-<fullname>-owner-secret`, but the operator derives that Secret with a plural suffix — and the chart's own `redis.external` default at `values.yaml:249` already said `-owner-secrets`. The two branches disagreed with each other. Net effect: the chart installs cleanly, the `RedisClaim` binds, the operator is healthy, and the pod sits in `CreateContainerConfigError` on a Secret nobody creates.

One character. Confirmed against real Helm rather than by inspection:

```
$ helm template … --set redis.internal.enabled=false --set redis.redisClaim.enabled=true
- name: REDIS_URI
  valueFrom:
    secretKeyRef:
      name: redis-passmower-owner-secrets     # matches the RedisClaim named "passmower"
      key: REDIS_MASTER_0_URI
```

`helm lint` clean, and the `internal` and `external` branches still render as before.

## #237 — README named a 1.x Secret key

The worked example read `OIDC_GATEWAY_AUTH_URI`. Keys were renamed to `OIDC_IDP_*` for 2.0, and `grep` confirms the README was the **last place in the repo** the old name survived — so copying the example verbatim produced a Deployment stuck on a key that isn't in the Secret.

Fixed, and I took the issue's optional suggestion: the section now enumerates all fifteen keys, since the example shows three and nothing else lists the rest.

## #238 — unusable username prefill

With `USERNAME_SOURCE=prompt`, the form was prefilled with the raw upstream `preferred_username`. Where that's an email (a UPN on Entra ID) it breaks four of the five `USERNAME_RULES`, so a new user's first interaction is clearing a field that cannot be submitted. Now run through `sanitizeUsername`, exactly as the `upstream` branch four lines below already does, keeping the raw value only when sanitizing leaves nothing.

One correction to that report: the template renders with `<%= %>`, which EJS HTML-escapes, so the raw upstream value reaching the input was never an injection path — this is a UX fix, not a security one.

## Tests

The two silent-drift bugs get **drift guards** rather than point assertions, since both were invisible for a release or more:

- `chart-secret-references.test.js` ties the chart's redis Secret references to the `values.yaml` default they have to agree with (and that both read `REDIS_MASTER_0_URI`).
- `readme-secret-keys.test.js` ties every `OIDC_*` key named in the README to the constants the Secret is actually written from, asserts no `OIDC_GATEWAY_*` leftovers, and asserts the new table stays **complete** as keys are added.
- `username-prompt-prefill.test.js` drives the real enrollment path and asserts what lands in the interaction result — sanitized suggestion, already-valid value untouched, raw fallback when nothing survives, plus a case pinning that `prompt` and `upstream` now suggest the same thing.

All three verified to **fail on the original bugs** (reverted each in turn), then pass. Suites: unit 65 files / 327 tests, integration 51, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)