### PR TITLE
ci: drop the unused Google Chrome apt source before installing browsers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,15 @@ jobs:
           npm --prefix frontend ci && npm --prefix frontend run build
           npm --prefix styles ci && npm --prefix styles run sass-prod
 
+      # Chromium itself comes from Playwright's CDN, but `--with-deps` runs
+      # apt-get update, which refreshes every source on the runner image —
+      # including Google's Chrome repo, which this job never uses. When that
+      # repo served an index inconsistent with its release file, apt failed with
+      # `Hash Sum mismatch` and every job in the repo died before a test ran.
+      # Drop the source so a third-party mirror cannot take CI out again.
+      - name: Drop the unused Google Chrome apt source
+        run: sudo rm -f /etc/apt/sources.list.d/google-chrome*
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
Every PR in the repo is currently blocked by a third-party apt mirror the build does not depend on. This takes it off the critical path.

## What happened

The e2e job died in `Install Playwright browser`, before any test ran:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
   Release file created at: Wed, 09 Sep 2026 17:16:59 +0000
   Last modification reported: Wed, 09 Sep 2026 09:41:12 +0000
```

Google's Chrome apt repo is serving an index inconsistent with its own release file. A re-run failed identically, so the fault is upstream, not flake. Last green e2e on `develop` was 08:19, before that 17:16 release file appeared.

## Why it reaches us at all

The job installs **Chromium from Playwright's CDN** — it does not use Google Chrome. But `--with-deps` runs `apt-get update`, and that refreshes *every* source configured on the `ubuntu-latest` image, including the Chrome repo that ships preconfigured there. One broken source fails the whole update.

## The change

Remove that source before the install, keeping the system dependencies `--with-deps` genuinely needs:

```yaml
- name: Drop the unused Google Chrome apt source
  run: sudo rm -f /etc/apt/sources.list.d/google-chrome*
```

The glob covers both the `.list` and deb822 `.sources` layouts, and `rm -f` is a no-op if the runner image stops shipping it.

## Verification

The outage is live right now, so this PR's own e2e job is a real test of the fix: if it goes green while `develop` is still red for this reason, the source removal is what did it. I'll report the result rather than assume it.

Unblocks #239 (three reported bug fixes), whose unit and integration jobs pass and whose e2e cannot exercise the changed code anyway — `test/e2e/passmower.env` sets `USERNAME_SOURCE=generated`, and no e2e spec touches the username form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)