### PR TITLE
fix: record admin approval instead of forging the required group (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,24 @@ access policies, so deleted or newly ineligible users cannot retain access for
 the full refresh-token lifetime. See
 [docs/refresh-token-authorization.md](docs/refresh-token-authorization.md).
 
+### Approval
+
+When `requiredGroup` is set, an account needs it (or `adminGroup`) to sign in
+anywhere. Both are matched against full group identifiers — `<prefix>:<name>`,
+where local groups carry `groupPrefix` and upstream ones the provider's prefix —
+so a value without a prefix matches nothing and is warned about at boot.
+
+An administrator can also approve an account directly from the admin panel,
+which records `spec.passmower.approved: true` on the `OIDCUser` and satisfies
+the policy on its own. That is the override for someone who should have access
+but cannot be added to the required group — the usual case when the group is
+synced from a directory. Approval is deliberately *not* implemented by granting
+the account the required group: local groups are merged into the account's
+groups, so granting an upstream group would publish a directory membership the
+user does not have to every client's `groups` claim and `allowedGroups` check.
+When `requiredGroup` is a local group, approval grants it as well, so clients
+gating on that group keep seeing approved users.
+
 ```
 apiVersion: codemowers.cloud/v1
 kind: OIDCUser

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -521,6 +521,14 @@ spec:
                         type: string
                 name:
                   type: string
+                approved:
+                  type: boolean
+                  description: >-
+                    Set by an administrator approving this account against the
+                    REQUIRED_GROUP policy. Recorded here rather than by granting
+                    the required group, so approval works when REQUIRED_GROUP
+                    names an upstream group and Passmower never writes a
+                    directory group onto an account that is not in it.
                 onboardedBy:
                   type: string
                   description: Account ID of the administrator who invited this user

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -14,8 +14,12 @@ passmower:
   # Local groups will be created with given prefix.
   groupPrefix: "passmower"
   # Local or remote group which members will automatically become admins.
+  # Use the full "prefix:name" identifier — local groups carry groupPrefix,
+  # upstream ones the provider's prefix. An unprefixed value matches no group.
   adminGroup: ""
   # If set, require all users to be member of the given local or remote group.
+  # Full "prefix:name" identifier, as with adminGroup. Administrators can also
+  # approve individual accounts, which satisfies this without the group.
   requiredGroup: ""
   # Authenticated, read-only directory of members of selected groups. Empty by
   # default: no roles or user contact details are exposed until explicitly set.

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import KubeScimConnectionOperator from "./operators/kube-scim-connection-operato
 import metricsServer from "./routes/metrics-server.js";
 import {getUsernameSource} from "./utils/username-source.js";
 import {validateEmailConfiguration} from './utils/email-configuration.js';
+import {validateGroupConfiguration} from './utils/group-configuration.js';
 import {getActivityTracker} from './services/activity-tracker.js';
 import KubeOidcUserEventHookOperator from './operators/kube-oidc-user-event-hook-operator.js';
 
@@ -70,6 +71,7 @@ export async function main() {
         setupLogger()
         getUsernameSource() // validate USERNAME_SOURCE (and warn on deprecated flags) at boot
         validateEmailConfiguration()
+        validateGroupConfiguration() // warn on REQUIRED_GROUP/ADMIN_GROUP that can never match
         const provider = await buildProvider()
         server = provider.listen(PORT, () => {
         globalThis.logger.info(`application is listening on port ${PORT}, check its /.well-known/openid-configuration`);

--- a/src/conditions/approved.js
+++ b/src/conditions/approved.js
@@ -1,23 +1,39 @@
 import {BaseCondition} from "./base-condition.js";
-import {AdminGroup} from "../models/account.js";
+import {AdminGroup, GroupPrefix} from "../models/account.js";
 
+// Whether an account satisfies the global REQUIRED_GROUP policy. Two things can
+// satisfy it: membership of that group (or of ADMIN_GROUP), or an explicit
+// approval by an administrator.
+//
+// Approval used to be implemented by granting the account the required group
+// with the *local* prefix substituted in, which meant it only ever worked when
+// REQUIRED_GROUP was a local group — and reported success regardless (#235).
+// It is now recorded as its own fact, so approving works whatever
+// REQUIRED_GROUP names, and Passmower never writes a group belonging to an
+// upstream directory onto an account that is not in it.
 export class Approved extends BaseCondition {
     type = 'Approved'
     requiredGroup = process.env.REQUIRED_GROUP
 
     check(account) {
-        const accountGroups = account.getProfileResponse().groups
-        return this.requiredGroup ?
-            accountGroups.find(g => g.displayName === this.requiredGroup || g.displayName === AdminGroup)
-            : true // don't require any group if REQUIRED_GROUP is not set
+        if (!this.requiredGroup) {
+            return true // don't require any group if REQUIRED_GROUP is not set
+        }
+        if (account?.isApproved()) {
+            return true
+        }
+        const accountGroups = account?.getProfileResponse()?.groups ?? []
+        return accountGroups.some(g => g.displayName === this.requiredGroup || g.displayName === AdminGroup)
     }
 
     add(account) {
-        if (this.requiredGroup && this.requiredGroup.includes(':')) {
-            const parts = this.requiredGroup.split(':')
-            parts.splice(0, 1)
-            const requiredGroupName = parts.join(':')
-            return account.pushCustomGroup(requiredGroupName)
+        account.setApproved()
+        // When REQUIRED_GROUP is a group Passmower owns, keep granting it as
+        // well: clients gating on that group with allowedGroups have always
+        // seen approved users, and that should not change.
+        const localPrefix = GroupPrefix ? `${GroupPrefix}:` : null
+        if (localPrefix && this.requiredGroup?.startsWith(localPrefix)) {
+            account.pushCustomGroup(this.requiredGroup.slice(localPrefix.length))
         }
         return account
     }

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -403,11 +403,28 @@ class Account {
         return this.#github?.id
     }
 
+    // Passmower's own approval of this account, recorded as a fact rather than
+    // expressed as group membership. Approval must not be a group write: local
+    // groups here are merged into status.groups by getIntendedStatus, so
+    // granting the account a group belonging to an upstream directory would put
+    // a group the user is not actually in into their groups claim and into
+    // every other client's allowedGroups check (#235).
+    setApproved() {
+        this.#passmower ??= {}
+        this.#passmower.approved = true
+        return this
+    }
+
+    isApproved() {
+        return this.#passmower?.approved === true
+    }
+
     pushCustomGroup(name) {
         const group = {
             prefix: GroupPrefix,
             name
         }
+        this.#passmower ??= {}
         if (!this.#passmower.groups) {
             this.#passmower.groups = []
         }

--- a/src/utils/group-configuration.js
+++ b/src/utils/group-configuration.js
@@ -1,0 +1,24 @@
+// REQUIRED_GROUP and ADMIN_GROUP are matched against group display names, which
+// are always "<prefix>:<name>" — a local group carries GROUP_PREFIX, an upstream
+// one carries the provider's prefix. A value without a prefix therefore matches
+// no group at all: an unprefixed ADMIN_GROUP makes nobody an admin, and an
+// unprefixed REQUIRED_GROUP cannot be satisfied by directory membership.
+//
+// This warns rather than throwing. An install running with a malformed value is
+// degraded but serving, and failing at boot on upgrade would turn that into a
+// crash loop; since administrators can now approve users whatever
+// REQUIRED_GROUP says (#235), a loud warning leaves a working way out.
+export function validateGroupConfiguration(env = process.env, logger = globalThis.logger) {
+    const problems = []
+    for (const name of ['REQUIRED_GROUP', 'ADMIN_GROUP']) {
+        const value = env[name]
+        if (value && !value.includes(':')) {
+            problems.push(`${name}="${value}" has no "<prefix>:<name>" prefix, so it matches no group`)
+        }
+    }
+    for (const problem of problems) {
+        logger?.warn({configuration: problem},
+            'Group configuration cannot match any group; expected "<prefix>:<name>"')
+    }
+    return problems
+}

--- a/test/unit/admin-approval.test.js
+++ b/test/unit/admin-approval.test.js
@@ -1,0 +1,155 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// GroupPrefix is read at module load, so each case re-imports under a stubbed
+// environment (the pattern username-source.test.js uses).
+async function withGroups({groupPrefix = 'passmower', requiredGroup = ''} = {}) {
+    vi.resetModules()
+    vi.stubEnv('GROUP_PREFIX', groupPrefix)
+    vi.stubEnv('REQUIRED_GROUP', requiredGroup)
+    const {default: Account} = await import('../../src/models/account.js')
+    const {Approved} = await import('../../src/conditions/approved.js')
+    return {Account, Approved}
+}
+
+const user = (Account, {groups = [], passmower = {}} = {}) => new Account().fromKubernetes({
+    metadata: {name: 'alice', labels: {}},
+    spec: {},
+    passmower,
+    status: {
+        profile: {name: 'Alice'},
+        groups: groups.map(displayName => {
+            const [prefix, ...rest] = displayName.split(':')
+            return {prefix, name: rest.join(':')}
+        }),
+        conditions: [],
+        termsOfService: {acceptedAt: '2026-08-21T10:00:00.000Z', contentHash: 'hash'},
+    },
+})
+
+beforeEach(() => {
+    globalThis.logger = {debug() {}, info() {}, warn: vi.fn(), error() {}, trace() {}}
+})
+afterEach(() => vi.unstubAllEnvs())
+
+describe('approving against an upstream REQUIRED_GROUP', () => {
+    // The reported case: the required group is synced from a directory, so it
+    // cannot be granted locally — approving used to write passmower:employees
+    // and report success while the check kept failing against entraid:employees.
+    const upstream = {groupPrefix: 'passmower', requiredGroup: 'entraid:employees'}
+
+    it('makes the account pass the check it exists to satisfy', async () => {
+        const {Account, Approved} = await withGroups(upstream)
+        const account = user(Account)
+        expect(new Approved().check(account)).toBe(false)
+
+        new Approved().add(account)
+
+        expect(new Approved().check(account)).toBe(true)
+    })
+
+    it('never writes the upstream group onto the account', async () => {
+        const {Account, Approved} = await withGroups(upstream)
+        const account = user(Account)
+
+        new Approved().add(account)
+
+        // Local groups are merged into status.groups and from there into the
+        // groups claim and other clients' allowedGroups checks, so a forged
+        // entraid:employees would be indistinguishable from real membership.
+        expect(account.getSpecs().passmower.groups ?? []).toEqual([])
+        expect(account.getSpecs().passmower.approved).toBe(true)
+    })
+
+    it('persists through the specs the admin routes write', async () => {
+        const {Account, Approved} = await withGroups(upstream)
+        const account = user(Account)
+
+        new Approved().add(account)
+
+        // Account.approve() hands getSpecs() to updateUserSpecs, so anything
+        // outside that projection would be silently dropped.
+        expect(account.getSpecs()).toMatchObject({passmower: {approved: true}})
+    })
+})
+
+describe('approving against a local REQUIRED_GROUP', () => {
+    const local = {groupPrefix: 'passmower', requiredGroup: 'passmower:staff'}
+
+    it('still grants the group, so clients gating on it keep working', async () => {
+        const {Account, Approved} = await withGroups(local)
+        const account = user(Account)
+
+        new Approved().add(account)
+
+        expect(account.getSpecs().passmower.groups).toEqual([{prefix: 'passmower', name: 'staff'}])
+        expect(new Approved().check(account)).toBe(true)
+    })
+
+    it('accepts an account that is already in the group, without approval', async () => {
+        const {Account, Approved} = await withGroups(local)
+
+        expect(new Approved().check(user(Account, {groups: ['passmower:staff']}))).toBe(true)
+    })
+})
+
+describe('the approval check', () => {
+    it('passes everyone when no group is required', async () => {
+        const {Account, Approved} = await withGroups({requiredGroup: ''})
+
+        expect(new Approved().check(user(Account))).toBe(true)
+    })
+
+    it('accepts membership of the required group or of ADMIN_GROUP', async () => {
+        vi.stubEnv('ADMIN_GROUP', 'entraid:platform')
+        const {Account, Approved} = await withGroups({requiredGroup: 'entraid:employees'})
+
+        expect(new Approved().check(user(Account, {groups: ['entraid:employees']}))).toBe(true)
+        expect(new Approved().check(user(Account, {groups: ['entraid:platform']}))).toBe(true)
+        expect(new Approved().check(user(Account, {groups: ['entraid:contractors']}))).toBe(false)
+    })
+
+    it('reports a boolean rather than the matched group', async () => {
+        // getProfileResponse() puts this straight in an API response.
+        const {Account, Approved} = await withGroups({requiredGroup: 'entraid:employees'})
+
+        expect(new Approved().check(user(Account, {groups: ['entraid:employees']}))).toBe(true)
+    })
+
+    it('recognises an approval recorded on the resource', async () => {
+        // GitOps: an operator can set spec.passmower.approved directly.
+        const {Account, Approved} = await withGroups({requiredGroup: 'entraid:employees'})
+
+        expect(new Approved().check(user(Account, {passmower: {approved: true}}))).toBe(true)
+    })
+})
+
+describe('group configuration validation', () => {
+    it('warns about a value that cannot match any group', async () => {
+        const {validateGroupConfiguration} = await import('../../src/utils/group-configuration.js')
+
+        expect(validateGroupConfiguration({REQUIRED_GROUP: 'employees'})).toEqual([
+            'REQUIRED_GROUP="employees" has no "<prefix>:<name>" prefix, so it matches no group',
+        ])
+        expect(validateGroupConfiguration({ADMIN_GROUP: 'admins'})).toHaveLength(1)
+        expect(validateGroupConfiguration({REQUIRED_GROUP: 'admins', ADMIN_GROUP: 'admins'}))
+            .toHaveLength(2)
+    })
+
+    it('accepts prefixed values and absent ones', async () => {
+        const {validateGroupConfiguration} = await import('../../src/utils/group-configuration.js')
+
+        expect(validateGroupConfiguration({
+            REQUIRED_GROUP: 'entraid:employees', ADMIN_GROUP: 'passmower:admins',
+        })).toEqual([])
+        expect(validateGroupConfiguration({})).toEqual([])
+        expect(validateGroupConfiguration({REQUIRED_GROUP: ''})).toEqual([])
+    })
+
+    it('warns rather than throwing, so a misconfigured install still boots', async () => {
+        const {validateGroupConfiguration} = await import('../../src/utils/group-configuration.js')
+        const logger = {warn: vi.fn()}
+
+        expect(() => validateGroupConfiguration({ADMIN_GROUP: 'admins'}, logger)).not.toThrow()
+        expect(logger.warn).toHaveBeenCalledTimes(1)
+    })
+})

--- a/test/unit/crd-schema.test.js
+++ b/test/unit/crd-schema.test.js
@@ -14,6 +14,18 @@ describe('OIDCUser CRD schema', () => {
         expect(passmower).toContain('onboardedBy:')
     })
 
+    it('declares the admin approval marker as a boolean under passmower', () => {
+        // Approval is recorded here rather than by granting the required group,
+        // so the field has to exist on every served version or the write is
+        // pruned and approving silently does nothing again (#235).
+        const oidcUserCrd = loadAll(crds).find(doc => doc?.metadata?.name === 'oidcusers.codemowers.cloud')
+
+        for (const version of oidcUserCrd.spec.versions) {
+            const passmower = version.schema.openAPIV3Schema.properties.passmower.properties
+            expect(passmower.approved.type).toBe('boolean')
+        }
+    })
+
     it('declares Terms of Service acceptance in status rather than spec', () => {
         const oidcUserSchema = crds.slice(crds.indexOf('&oidcUserSchema'), crds.indexOf('\n    additionalPrinterColumns:', crds.indexOf('&oidcUserSchema')))
         const specStart = oidcUserSchema.indexOf('\n            spec:')


### PR DESCRIPTION
Fixes #235 (needs closing by hand — PRs into `develop` don't auto-close).

**Heads up: this takes neither of the two fixes suggested on the issue.** Same reason rules both out, so that argument is first.

## The bug

Confirmed exactly as reported: `add()` splices the prefix off `REQUIRED_GROUP`, `pushCustomGroup` unconditionally re-adds `GROUP_PREFIX`, and `check()` compares against the full `REQUIRED_GROUP`. With `REQUIRED_GROUP=entraid:employees` and `GROUP_PREFIX=passmower`, approving writes `passmower:employees`, the check keeps failing against `entraid:employees`, and the user stays on the approval screen. The silence is real too — `Account.approve` ignores what `add()` returns, and the route logs `Admin approved user` and returns 200 regardless.

## Why not "preserve the prefix"

Because `spec.passmower.groups` is not a private scratchpad. `getIntendedStatus` merges it into `status.groups`, which feeds **the `groups` claim sent to every client** and **other clients' `allowedGroups` checks**. Writing `entraid:employees` there makes the account indistinguishable from a real member of that directory group, everywhere. An admin granting Passmower access would silently grant apps that trust `entraid:employees` for authorization — a worse bug than the one being fixed, and a quiet one.

## Why not "refuse when the prefix isn't local"

`values.yaml` documents both `adminGroup` and `requiredGroup` as "Local **or remote** group", so upstream is a supported configuration — and as the issue notes, it's the configuration where approve is *most* useful, since the group being directory-synced is exactly why someone can't be added to it. Refusing removes the feature from the case it exists for.

## What landed

Approval becomes its own recorded fact, `spec.passmower.approved`, and the check passes on **either** that or group membership:

```js
check(account) {
    if (!this.requiredGroup) return true
    if (account?.isApproved()) return true
    const accountGroups = account?.getProfileResponse()?.groups ?? []
    return accountGroups.some(g => g.displayName === this.requiredGroup || g.displayName === AdminGroup)
}
```

So approving works whatever `REQUIRED_GROUP` names, and nothing is forged. **When `REQUIRED_GROUP` is a local group it is still granted as well**, so clients gating on that group with `allowedGroups` keep seeing approved users — no behaviour change for installs where approve already worked, and no migration: previously-approved users are in the group, so the group branch still passes.

It persists through the existing path — `#passmower` is part of `getSpecs()`, which is what `Account.approve` hands to `updateUserSpecs` — so both admin entry points (approve and invite) are fixed by the one change, and a GitOps operator can set the field directly.

## The extra case from verification

An **unprefixed** `REQUIRED_GROUP` or `ADMIN_GROUP` can never match anything, since both are compared against `<prefix>:<name>` display names — so nobody is admin, or nobody passes approval, silently, and there was no validation anywhere. Now warned at boot next to the existing `USERNAME_SOURCE` and email checks.

It **warns rather than throws**, deliberately: such an install is degraded but serving, and failing at boot would turn that into a crash loop on upgrade, while approval now gives the operator a way through. Happy to make it fatal if you'd rather.

## Also

`check()` now returns a boolean rather than the matched group object. It feeds `approved` in the admin API response; the frontend only tests truthiness (`v-if="!account.approved"`), so this just stops an internal object leaking into an API payload.

## Tests

`test/unit/admin-approval.test.js` (12) leads with the reported scenario: with an upstream `REQUIRED_GROUP`, the account fails the check, is approved, and then passes — plus an assertion that **no group was written**, since that's the trap the other fix would have fallen into. Then: persistence through `getSpecs()`; the local-group path still granting the group; existing membership; `ADMIN_GROUP`; no required group; a GitOps-set marker; the boolean shape; and the boot-validation matrix including that it doesn't throw. 8 of the 12 fail against the old implementation (verified by reverting).

`crd-schema.test.js` asserts `passmower.approved` is declared boolean on **both served versions** — if it were missing from one, the write would be pruned and approving would silently do nothing all over again.

Suites: unit 66 files / 340 tests, integration 51, all green. `helm lint` clean.

**Not** verified against a live API server this time: minikube is stopped in this session, so the CRD change is covered by the parsed-schema test rather than a server-side dry run like the last chart change.

## Docs

`values.yaml` comments now state the `prefix:name` requirement, and the README's enrollment section gains a short *Approval* subsection covering both ways the policy can be satisfied and why approval isn't a group grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)