### PR TITLE
fix: converge on one client secret instead of rotating it (#236)

### DIFF
--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -305,6 +305,13 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Passmower's HTTP side is stateless (sessions in Redis, signing keys in a
+# Secret), but each replica also runs the CRD operators, and they are not
+# leader-elected — the instance identity they claim resources with is per
+# Deployment, not per Pod, so every replica reconciles every event. Reconciles
+# converge rather than corrupt (see #236), but raising this above 1 buys
+# duplicated work and API churn, not throughput. Leader election is tracked in
+# #236.
 replicaCount: 1
 
 resources: {}

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -259,7 +259,10 @@ export class KubernetesAdapter {
         })
     }
 
-    async createSecret(namespace, id, data, metadata) {
+    // `ignoreAlreadyExists` reports a 409 as {alreadyExists: true} instead of a
+    // failure, so a caller racing another writer can adopt the Secret that won
+    // rather than treat the collision as an error (same contract as createJob).
+    async createSecret(namespace, id, data, metadata, {ignoreAlreadyExists = false} = {}) {
         let kubeSecret = new V1Secret()
         kubeSecret.metadata = {
             name: id,
@@ -272,6 +275,10 @@ export class KubernetesAdapter {
         }, this.defaultOptions).then(async (r) => {
             return this.#parseSecretData(r.data)
         }).catch((e) => {
+            const statusCode = e.code ?? e.statusCode ?? e.response?.statusCode
+            if (ignoreAlreadyExists && statusCode === 409) {
+                return {alreadyExists: true}
+            }
             globalThis.logger.error(e)
             return null
         })

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -37,20 +37,7 @@ export class KubeOIDCClientOperator {
             this.#assertValidClaimMappings(OIDCClient)
             if (OIDCClient.getInstance() === this.instance) {
                 if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
-                    let secret = await this.adapter.getSecret(
-                        OIDCClient.getClientNamespace(),
-                        OIDCClient.getSecretName()
-                    )
-                    if (secret) {
-                        OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
-                    } else {
-                        OIDCClient.generateSecret()
-                        await this.adapter.deleteSecret(
-                            OIDCClient.getClientNamespace(),
-                            OIDCClient.getSecretName()
-                        )
-                        await this.#createKubeSecret(OIDCClient)
-                    }
+                    await this.#reconcileClientSecret(OIDCClient)
                 }
             } else if (!OIDCClient.getInstance()) {
                 // Claim that client. Continue with the returned resource so later
@@ -58,8 +45,7 @@ export class KubeOIDCClientOperator {
                 const claimedClient = await this.#replaceClientStatus(OIDCClient)
                 if (claimedClient?.getInstance() === this.instance) {
                     OIDCClient = claimedClient
-                    OIDCClient.generateSecret()
-                    await this.#createKubeSecret(OIDCClient)
+                    await this.#reconcileClientSecret(OIDCClient)
                 } else {
                     return
                 }
@@ -107,22 +93,12 @@ export class KubeOIDCClientOperator {
                 await this.#reportReady(OIDCClient, 'Disabled', 'Client is disabled and absent from Redis')
                 return
             }
+            // Debounce the burst of MODIFIED events our own status writes
+            // produce. This used to also paper over the ADDED path still
+            // creating the Secret; #reconcileClientSecret no longer needs the
+            // head start, since whichever reconcile gets there first wins.
             await new Promise(res => setTimeout(res, 1000));
-            let secret = await this.adapter.getSecret(
-                OIDCClient.getClientNamespace(),
-                OIDCClient.getSecretName()
-            )
-            if (secret) {
-                OIDCClient.setSecret(secret.data[OIDCClientSecretClientSecretKey])
-                await this.#patchKubeSecret(OIDCClient, secret)
-            } else {
-                OIDCClient.generateSecret()
-                await this.adapter.deleteSecret(
-                    OIDCClient.getClientNamespace(),
-                    OIDCClient.getSecretName()
-                )
-                await this.#createKubeSecret(OIDCClient)
-            }
+            await this.#reconcileClientSecret(OIDCClient)
             await this.redisAdapter.upsert(OIDCClient.getClientId(), OIDCClient.toRedis())
             await this.#reportReady(OIDCClient, 'Reconciled', 'Client reconciliation completed successfully')
         } catch (error) {
@@ -130,24 +106,48 @@ export class KubeOIDCClientOperator {
         }
     }
 
-    async #createKubeSecret(OIDCClient) {
-        const secret = await this.adapter.createSecret(
-            OIDCClient.getClientNamespace(),
-            OIDCClient.getSecretName(),
+    // Converge on one client_secret. Reconciles of the same client overlap: the
+    // watch callback is not awaited between events, so an ADDED and the
+    // MODIFIED our own status write provokes can be in flight together, and
+    // every replica reconciles every event because the instance identity is
+    // per-Deployment, not per-Pod. Generating a secret and deleting whatever
+    // was there — what this used to do — meant each reconcile installed its own
+    // secret and upserted that one to Redis, so the application could end up
+    // holding a secret the provider had already replaced, and authentication
+    // failed with invalid_client until something reconciled again (#236).
+    //
+    // Whoever creates the Secret first wins; everyone else adopts it. Nothing
+    // here deletes a Secret, so a client_secret is never rotated as a
+    // side effect of a reconcile.
+    async #reconcileClientSecret(OIDCClient) {
+        const namespace = OIDCClient.getClientNamespace()
+        const name = OIDCClient.getSecretName()
+        const existing = await this.adapter.getSecret(namespace, name)
+        if (existing) {
+            return await this.#adoptKubeSecret(OIDCClient, existing)
+        }
+        OIDCClient.generateSecret()
+        const created = await this.adapter.createSecret(
+            namespace,
+            name,
             OIDCClient.toClientSecret(this.provider),
             OIDCClient.toClientSecretMetadata(),
+            {ignoreAlreadyExists: true},
         )
-        if (!secret) throw this.#reconcileError('SecretReconcileFailed', 'Failed to create client Secret')
-        if (OIDCClient.getSecretRefreshJob()) {
-            const job = await this.adapter.createJob(
-                OIDCClient.getClientNamespace(),
-                OIDCClient.getSecretRefreshJob()
-            )
-            if (!job) throw this.#reconcileError('RefreshJobReconcileFailed', 'Failed to create secret-refresh Job')
+        if (created?.alreadyExists) {
+            // Lost the race; take the winner's secret rather than ours.
+            const secret = await this.adapter.getSecret(namespace, name)
+            if (!secret) {
+                throw this.#reconcileError('SecretReconcileFailed', 'Client Secret exists but could not be read')
+            }
+            return await this.#adoptKubeSecret(OIDCClient, secret)
         }
+        if (!created) throw this.#reconcileError('SecretReconcileFailed', 'Failed to create client Secret')
+        await this.#reconcileRefreshJob(OIDCClient)
     }
 
-    async #patchKubeSecret(OIDCClient, existingSecret) {
+    async #adoptKubeSecret(OIDCClient, existingSecret) {
+        OIDCClient.setSecret(existingSecret.data[OIDCClientSecretClientSecretKey])
         const secret = await this.adapter.patchSecret(
             OIDCClient.getClientNamespace(),
             OIDCClient.getSecretName(),
@@ -156,13 +156,22 @@ export class KubeOIDCClientOperator {
             existingSecret
         )
         if (!secret) throw this.#reconcileError('SecretReconcileFailed', 'Failed to update client Secret')
-        if (OIDCClient.getSecretRefreshJob()) {
-            const job = await this.adapter.createJob(
-                OIDCClient.getClientNamespace(),
-                OIDCClient.getSecretRefreshJob()
-            )
-            if (!job) throw this.#reconcileError('RefreshJobReconcileFailed', 'Failed to create secret-refresh Job')
+        await this.#reconcileRefreshJob(OIDCClient)
+    }
+
+    // The Job name is derived from the client's resourceVersion, so an existing
+    // one means another reconcile of this same version already created it —
+    // success, not the failure it used to be reported as.
+    async #reconcileRefreshJob(OIDCClient) {
+        if (!OIDCClient.getSecretRefreshJob()) {
+            return
         }
+        const job = await this.adapter.createJob(
+            OIDCClient.getClientNamespace(),
+            OIDCClient.getSecretRefreshJob(),
+            {ignoreAlreadyExists: true},
+        )
+        if (!job) throw this.#reconcileError('RefreshJobReconcileFailed', 'Failed to create secret-refresh Job')
     }
 
     #reconcileError(reason, message) {

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -95,7 +95,15 @@ export class FakeKubernetesAdapter {
     // --- Secrets + pods (used by the client operator) -----------------------
 
     async getSecret(namespace, id) { return this.secrets.get(`${namespace}/${id}`) }
-    async createSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
+    // Creating over an existing Secret is a 409 in a real cluster; model that,
+    // or a test cannot see two reconciles racing on the same client.
+    async createSecret(namespace, id, data, metadata, {ignoreAlreadyExists = false} = {}) {
+        const key = `${namespace}/${id}`
+        if (this.secrets.has(key)) return ignoreAlreadyExists ? {alreadyExists: true} : null
+        const s = { data: structuredClone(data), metadata }
+        this.secrets.set(key, s)
+        return s
+    }
     async patchSecret(namespace, id, data, metadata) { const s = { data: structuredClone(data), metadata }; this.secrets.set(`${namespace}/${id}`, s); return s }
     async deleteSecret(namespace, id) { this.secrets.delete(`${namespace}/${id}`) }
     async createJob(namespace, jobManifest, {ignoreAlreadyExists = false} = {}) {

--- a/test/unit/client-secret-convergence.test.js
+++ b/test/unit/client-secret-convergence.test.js
@@ -1,0 +1,180 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js'
+import {KubeOIDCClientOperator} from '../../src/operators/kube-oidc-client-operator.js'
+
+class FakeRedisAdapter {
+    records = new Map()
+
+    async find(id) { return this.records.get(id) }
+    async upsert(id, value) { this.records.set(id, value) }
+    async destroy(id) { this.records.delete(id) }
+}
+
+const oidcClient = (name, {refreshJob = false} = {}) => ({
+    metadata: {name, namespace: 'apps', generation: 1, uid: `uid-${name}`, resourceVersion: '1'},
+    spec: {
+        grantTypes: ['authorization_code'], responseTypes: ['code'],
+        redirectUris: [`https://${name}.example.com/callback`], availableScopes: ['openid'],
+        ...(refreshJob
+            ? {secretRefreshJobSpec: {template: {spec: {containers: [{name: 'refresh', image: 'busybox'}]}}}}
+            : {}),
+    },
+    status: {},
+})
+
+const secretOf = (adapter, name = 'grafana') =>
+    adapter.secrets.get(`apps/oidc-client-${name}-owner-secrets`)?.data?.OIDC_CLIENT_SECRET
+
+describe('client secret convergence under overlapping reconciles', () => {
+    let adapter, redis, operator
+
+    beforeEach(async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.deployment = 'passmower'
+        redis = new FakeRedisAdapter()
+        operator = new KubeOIDCClientOperator(
+            {urlFor: endpoint => `https://id.example.com/${endpoint}`}, adapter, redis)
+        await operator.watchClients()
+    })
+
+    // The multi-replica case: every pod receives its own ADDED for the same
+    // object, and the instance identity is per-Deployment so each pod believes
+    // the client is its own to reconcile.
+    it('issues exactly one secret when two reconciles race a new client', async () => {
+        // Every client_secret that actually lands in the Secret. Both reconciles
+        // *generate* one — the loser's is then refused by the 409, which is the
+        // point — so what matters is how many distinct values get installed.
+        // Counting only the end state would miss it: the loser's value can be
+        // the one the application already read.
+        const issued = new Set()
+        const create = adapter.createSecret.bind(adapter)
+        const patch = adapter.patchSecret.bind(adapter)
+        adapter.createSecret = async (ns, id, data, ...rest) => {
+            const result = await create(ns, id, data, ...rest)
+            if (result && !result.alreadyExists) issued.add(data.OIDC_CLIENT_SECRET)
+            return result
+        }
+        adapter.patchSecret = async (ns, id, data, ...rest) => {
+            const result = await patch(ns, id, data, ...rest)
+            if (result) issued.add(data.OIDC_CLIENT_SECRET)
+            return result
+        }
+        adapter.seed('OIDCClient', oidcClient('grafana'))
+
+        await Promise.all([
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+        ])
+
+        expect([...issued]).toHaveLength(1)
+        // And the value the application reads is the value the provider holds.
+        expect(secretOf(adapter)).toBe([...issued][0])
+        expect(redis.records.get('apps.grafana').client_secret).toBe(secretOf(adapter))
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'True', reason: 'Reconciled'}))
+    })
+
+    it('never deletes a client Secret while reconciling', async () => {
+        const deleteSecret = vi.spyOn(adapter, 'deleteSecret')
+        adapter.seed('OIDCClient', oidcClient('grafana'))
+
+        await Promise.all([
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+        ])
+
+        // Rotating a client_secret breaks the consuming app until its workload
+        // restarts, so it must never be a side effect of reconciling.
+        expect(deleteSecret).not.toHaveBeenCalled()
+    })
+
+    it('adopts an existing secret rather than issuing a new one', async () => {
+        adapter.secrets.set('apps/oidc-client-grafana-owner-secrets', {
+            data: {OIDC_CLIENT_SECRET: 'secret-from-a-previous-reconcile'},
+            metadata: {},
+        })
+        adapter.seed('OIDCClient', oidcClient('grafana'))
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        expect(secretOf(adapter)).toBe('secret-from-a-previous-reconcile')
+        expect(redis.records.get('apps.grafana').client_secret)
+            .toBe('secret-from-a-previous-reconcile')
+    })
+
+    it('adopts the winner when the Secret appears between the read and the create', async () => {
+        // The interleaving the 409 path exists for: nothing there when we look,
+        // something there when we write.
+        adapter.seed('OIDCClient', oidcClient('grafana'))
+        const create = adapter.createSecret.bind(adapter)
+        adapter.createSecret = async (namespace, id, data, metadata, options) => {
+            adapter.secrets.set(`${namespace}/${id}`, {
+                data: {OIDC_CLIENT_SECRET: 'secret-from-the-other-replica'}, metadata: {},
+            })
+            adapter.createSecret = create
+            return await create(namespace, id, data, metadata, options)
+        }
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        expect(secretOf(adapter)).toBe('secret-from-the-other-replica')
+        expect(redis.records.get('apps.grafana').client_secret).toBe('secret-from-the-other-replica')
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'True'}))
+    })
+
+    it('fails loudly if the Secret exists but cannot be read back', async () => {
+        adapter.seed('OIDCClient', oidcClient('grafana'))
+        adapter.createSecret = async () => ({alreadyExists: true})
+        adapter.getSecret = async () => undefined
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        // Previously this shape was "repaired" by deleting and reissuing, which
+        // silently rotated the secret; an unreadable Secret is now surfaced.
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'False', reason: 'SecretReconcileFailed'}))
+        expect(redis.records.size).toBe(0)
+    })
+})
+
+describe('secret-refresh Job under overlapping reconciles', () => {
+    let adapter, redis, operator
+
+    beforeEach(async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.deployment = 'passmower'
+        redis = new FakeRedisAdapter()
+        operator = new KubeOIDCClientOperator(
+            {urlFor: endpoint => `https://id.example.com/${endpoint}`}, adapter, redis)
+        await operator.watchClients()
+    })
+
+    it('treats an already-created Job as done, not as a failure', async () => {
+        adapter.seed('OIDCClient', oidcClient('grafana', {refreshJob: true}))
+
+        await Promise.all([
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+            adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
+        ])
+
+        // The name is derived from the resourceVersion, so the second create is
+        // the same Job — one Job, and no spurious Warning on a healthy client.
+        expect(adapter.jobs).toHaveLength(1)
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'True', reason: 'Reconciled'}))
+        expect(adapter.events.filter(e => e.type === 'Warning')).toEqual([])
+    })
+
+    it('still reports a Job that genuinely could not be created', async () => {
+        adapter.createJob = async () => null
+        adapter.seed('OIDCClient', oidcClient('grafana', {refreshJob: true}))
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'False', reason: 'RefreshJobReconcileFailed'}))
+    })
+})


### PR DESCRIPTION
Option B from the #236 discussion: make the writers idempotent. Leaves leader election open on the issue, and adds the `replicaCount` comment from option A alongside.

## The finding that reordered this

The issue reads as "raising `replicaCount` is unsafe". It is, but the sharp edge is **already reachable at `replicaCount: 1`**:

- The watch callback handed to client-node is `async` and **not awaited between events** (`kubernetes.js:397-412`), so an ADDED and the MODIFIED our own status write provokes can be in flight together.
- `#updateOIDCClient` opens with `await new Promise(res => setTimeout(res, 1000))` before reading the Secret. That sleep is the existing mitigation for this race.

And the reason replicas make it worse: `this.instance = namespace + '-' + DEPLOYMENT_NAME` (`kubernetes.js:76`) is a **per-Deployment** identity, so `status.instance` claiming — which is the right mechanism for "two Passmowers, one cluster" — gives every replica the same name, and each concludes it owns every resource.

## The bug

Both reconcile paths handled a missing Secret by generating a fresh `client_secret`, **deleting** whatever Secret was there, creating their own, and upserting that secret to Redis. Two overlapping reconciles install two different secrets, and the application can be left holding one the provider has already replaced — `invalid_client` until something reconciles again.

## The fix

Whoever creates the Secret first wins; everyone else adopts it. `createSecret` gains the `ignoreAlreadyExists` option `createJob` already has and reports a 409 as `{alreadyExists: true}`; the operator then reads the Secret back and uses **that** secret rather than its own. Both paths and the claim path go through one `#reconcileClientSecret`.

**No path deletes a Secret any more**, so a `client_secret` is never rotated as a side effect of reconciling.

## Two consequences to weigh

1. **A Secret that exists but cannot be read is now `Ready=False` / `SecretReconcileFailed`** rather than being deleted and reissued. That shape was previously "repaired" by rotating the secret — which breaks the consuming app until its workload restarts — so I think naming it beats fixing it behind the operator's back, but it is a deliberate behaviour change and the one thing here I would push back on if you disagree.
2. **The refresh Job now uses `ignoreAlreadyExists`.** Its name is derived from the client's `resourceVersion`, so an existing Job means another reconcile of that same version already created it: success, not the `RefreshJobReconcileFailed` + Warning event a healthy client used to collect. A Job that genuinely fails to create still fails — covered by the existing test.

I left the 1s sleep in place, now commented as the debounce it still is for our own status-write echoes, rather than removing it in the same change and inviting a timing regression I can't fully test.

## Tests

`test/unit/client-secret-convergence.test.js` (7). The headline one asserts **exactly one secret is ever installed** when two ADDED events race — deliberately not an end-state assertion, since the loser's value can be the one the app already read, which is what makes this invisible in production. My first attempt at that test recorded *attempted* secrets and failed against the fixed code, which was the instrumentation being wrong: both reconciles generate a secret and the loser's being refused by the 409 *is* the protection. It now records only what actually lands.

Also covered: `deleteSecret` is never called; an existing secret is adopted rather than reissued; the Secret appearing between the read and the create is adopted; an unreadable Secret surfaces as a condition; the duplicate Job is not a failure; a genuine Job failure still is.

**The fake adapter now returns a 409 for a create over an existing Secret**, as a real cluster does. It previously overwrote silently — which is why no operator test could see any of this, the same gap that hid the missing `createSecret` return in #225. 6 of the 7 new tests fail against the old operator.

Suites: unit 67 files / 347 tests, integration 51, all green. `helm lint` clean.

## Still open on #236

Leader election (option C). Worth restating one point from the discussion: a Lease is **not** a substitute for this change — leases hand over on expiry, restarts and pauses, so two reconcilers can briefly overlap, and the writers have to be safe underneath it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)