### PR TITLE
fix: let the internal Redis take resources and scheduling (#242)

### DIFF
--- a/charts/passmower/templates/redis.yaml
+++ b/charts/passmower/templates/redis.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         app: redis
     spec:
+      {{- with .Values.redis.internal.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: redis
           image: {{ .Values.redis.internal.image | default "redis:7-alpine" }}
@@ -35,6 +38,20 @@ spec:
               value: "true"
           ports:
             - containerPort: 6379
+          resources:
+            {{- toYaml .Values.redis.internal.resources | nindent 12 }}
+      {{- with .Values.redis.internal.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.internal.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.internal.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -237,6 +237,23 @@ redis:
     enabled: true
     # Image for the internal (non-persistent) Redis. Pinned rather than :latest.
     image: redis:7-alpine
+    # Scheduling for the internal Redis, which holds every session and grant —
+    # losing it signs everyone out at once. With neither requests nor limits the
+    # pod is BestEffort, which is what a kubelet evicts first under node memory
+    # pressure, so on a node pool that sees pressure set at least a memory
+    # request here. Empty by default to keep upgrades from changing where an
+    # existing pod can schedule; the main Deployment's own knobs are the
+    # top-level resources/nodeSelector/affinity/tolerations.
+    resources: {}
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
+      # limits:
+      #   memory: 256Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    priorityClassName: ""
   # Use your own implementation. REDIS_URI remains supported through
   # secretKeyRef. Alternatively set host/port/username/database here and source
   # the password from a Secret, or import a Secret whose keys are REDIS_HOST,

--- a/test/unit/chart-redis-scheduling.test.js
+++ b/test/unit/chart-redis-scheduling.test.js
@@ -1,0 +1,42 @@
+import {readFileSync} from 'node:fs'
+import {load} from 'js-yaml'
+import {describe, expect, it} from 'vitest'
+
+const redis = readFileSync(
+    new URL('../../charts/passmower/templates/redis.yaml', import.meta.url), 'utf8')
+const values = load(readFileSync(
+    new URL('../../charts/passmower/values.yaml', import.meta.url), 'utf8'))
+
+// The internal Redis holds every session and grant, so losing it signs everyone
+// out at once — and with neither requests nor limits its pod is BestEffort,
+// first in line for eviction under node memory pressure. It was the only
+// workload in the release with no way to change that (#242).
+describe('internal Redis scheduling knobs', () => {
+    it('threads resources into the container', () => {
+        expect(redis).toContain('toYaml .Values.redis.internal.resources')
+    })
+
+    it('threads the scheduling knobs the main Deployment has', () => {
+        for (const knob of ['nodeSelector', 'affinity', 'tolerations', 'priorityClassName']) {
+            expect(redis).toContain(`.Values.redis.internal.${knob}`)
+        }
+    })
+
+    it('declares every knob in values.yaml, so toYaml cannot render null', () => {
+        const internal = values.redis.internal
+
+        expect(internal.resources).toEqual({})
+        expect(internal.nodeSelector).toEqual({})
+        expect(internal.affinity).toEqual({})
+        expect(internal.tolerations).toEqual([])
+        expect(internal.priorityClassName).toBe('')
+    })
+
+    it('leaves the defaults empty so an upgrade cannot move an existing pod', () => {
+        // A default request would change where the pod can schedule on upgrade,
+        // which is not something a patch release should do behind the operator's
+        // back; the commented example in values.yaml suggests one instead.
+        expect(values.redis.internal.resources).toEqual({})
+        expect(redis).not.toMatch(/memory:\s*\d/)
+    })
+})


### PR DESCRIPTION
Fixes #242 (needs closing by hand — PRs into `develop` don't auto-close).

Verified the report before touching anything: `redis.yaml` has no `resources` and `redis.internal` exposes exactly `{enabled, image}`, so no value could change the QoS class. BestEffort follows by definition from having neither requests nor limits.

The asymmetry is as described — the main Deployment threads `resources`, `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, `securityContext` and both probes; the Redis Deployment threaded none of them.

## The change

`resources`, `nodeSelector`, `affinity`, `tolerations` and `priorityClassName` plumbed through `redis.yaml`, mirroring the main Deployment. I took the four extra knobs the issue floated alongside `resources` — same one-line shape, same argument.

## Defaults deliberately stay empty

`helm template` with defaults is byte-identical to `develop` apart from `resources: {}` — the same thing the main Deployment renders:

```diff
            - containerPort: 6379
+          resources:
+            {}
```

A default request is defensible for this pod specifically, as the issue says, but adding one changes where an existing pod can schedule during an upgrade — not something this fix should do on its own. `values.yaml` carries a commented suggestion instead, with the eviction reasoning next to it, so the operator opts in.

## Verified

`helm lint` clean. Rendered with every knob set:

```yaml
    spec:
      priorityClassName: system-cluster-critical
      containers:
        - name: redis
          ...
          resources:
            limits:
              memory: 256Mi
            requests:
              memory: 128Mi
      nodeSelector:
        disktype: ssd
      tolerations:
        - key: dedicated
          operator: Exists
```

`test/unit/chart-redis-scheduling.test.js` (4) asserts the template threads all five, that **values.yaml declares each one** (an undeclared value would make `toYaml` render `null` and break the render), and that the defaults stay empty. All four fail without the change.

Suites: unit 68 files / 351 tests.

## Not covered

Still no probes on the Redis container, and no `topologySpreadConstraints` or `securityContext` — the issue lists those as part of the same asymmetry but they're a different shape of decision (a readiness probe changes rollout behaviour), so I left them out rather than bundle them in. Say if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)