### PR TITLE
fix: only issue refresh tokens to clients allowed the grant (#243)

### DIFF
--- a/docs/refresh-token-authorization.md
+++ b/docs/refresh-token-authorization.md
@@ -21,3 +21,69 @@ Clients should handle `invalid_grant` by discarding the refresh token and
 starting a new interactive authorization flow. If the account is still
 eligible, that flow can satisfy any newly required prompt and establish a new
 grant.
+
+## Getting a refresh token
+
+A refresh token goes to any client allowed the `refresh_token` grant. That is
+the whole requirement — add `refresh_token` to the client's `spec.grantTypes`:
+
+```yaml
+spec:
+  grantTypes:
+    - authorization_code
+    - refresh_token
+```
+
+`oidc-provider`'s own default also requires the `offline_access` scope in the
+grant, which OIDC Core §11 ties to `prompt=consent`. Passmower does not, because
+these tokens are not offline access: they expire with the session, so they only
+renew silently while the user is still signed in. Requiring the consent ceremony
+for that would take renewal away from every client whose relying party does not
+send the prompt, and buy nothing.
+
+| client `grantTypes` | refresh token | `offline_access` in the grant |
+|---|---|---|
+| includes `refresh_token` | yes | only with `prompt=consent` |
+| no `refresh_token` | no | no |
+
+A client without the grant gets none. It used to be handed one the token
+endpoint then refused with `requested grant type is not allowed for this
+client` — a dead credential rather than a feature. If its application asked for
+`offline_access`, that mismatch is logged, since it is otherwise silent
+(sign-in succeeds and only renewal is missing):
+
+```
+Refresh token withheld: client is not allowed the refresh_token grant
+  clientId: apps.grafana
+```
+
+## Where offline_access does and does not matter
+
+`offline_access` decides what the *grant* records, not whether a refresh token is
+issued. `oidc-provider` removes the scope from an authorization request unless
+**all three** hold (its authorization `scopes.js`):
+
+1. the response type returns an authorization code,
+2. the client is allowed the `refresh_token` grant, and
+3. the request carries **`prompt=consent`**.
+
+The third is the one that catches people:
+
+```
+GET /auth?client_id=…&scope=openid%20offline_access             → granted: openid
+GET /auth?client_id=…&scope=openid%20offline_access&prompt=consent
+                                                                → granted: openid offline_access
+```
+
+Note what is *not* on that list: `spec.availableScopes`. Passmower does not
+restrict requested scopes to it, so `offline_access` reaches the grant whether or
+not the client lists it — `availableScopes` only populates
+`OIDC_AVAILABLE_SCOPES` in the generated Secret and lets the grant carry the
+scope. Listing it tells the consuming application what it may request; it does
+not decide what is issued.
+
+Since `expiresWithSession` ends every token with the session regardless,
+`offline_access` in the grant currently records the request rather than granting
+an exemption from session lifetime. A relying party that genuinely needs access
+while the user is away should request it with `prompt=consent` — and know that
+the session still bounds it today.

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -254,10 +254,31 @@ export default {
     async expiresWithSession(ctx, code) {
         return true // always end whole session, also clients using refresh token with offline_access
     },
-    async issueRefreshToken(ctx, client, code) {
-        return true
-        // TODO: figure out why offline_access is stripped from scopes.
-        // return client.grantTypeAllowed('refresh_token') && code.scopes.has('offline_access');
+    // Refresh tokens go to any client allowed the refresh_token grant, whether
+    // or not offline_access was granted. oidc-provider's default additionally
+    // requires that scope, which OIDC Core §11 ties to prompt=consent — but
+    // these are not offline access: expiresWithSession above ends them with the
+    // session, so they only ever renew silently while the user is still signed
+    // in. Requiring the consent ceremony for that would buy nothing and take
+    // renewal away from every client whose relying party does not send the
+    // prompt. A relying party that wants true offline access requests
+    // offline_access with prompt=consent, and gets a grant carrying the scope.
+    //
+    // The grant-type half is not optional: without it a client is handed a
+    // refresh token the token endpoint then refuses with "requested grant type
+    // is not allowed for this client".
+    async issueRefreshToken(ctx, client, code) { // eslint-disable-line no-unused-vars
+        if (client.grantTypeAllowed('refresh_token')) {
+            return true
+        }
+        // Asked for offline access but cannot be given it — a client whose
+        // grantTypes and whose application disagree, which is otherwise silent:
+        // sign-in succeeds and only renewal is missing.
+        if ((ctx.oidc?.params?.scope ?? '').split(' ').includes('offline_access')) {
+            auditLog(ctx, {clientId: client.clientId},
+                'Refresh token withheld: client is not allowed the refresh_token grant')
+        }
+        return false
     },
     rotateRefreshToken(ctx) {
         // TODO: figure out how to prompt for changed conditions

--- a/src/utils/session/add-grants.js
+++ b/src/utils/session/add-grants.js
@@ -14,8 +14,13 @@ export const addGrant = async (provider, prompt, grantId, accountId, client) => 
     }
 
     if (prompt.details.missingOIDCScope) {
+        // offline_access is absent from missingOIDCScope unless the
+        // authorization request carried prompt=consent, which OIDC Core §11
+        // requires and oidc-provider enforces before the interaction. Adding it
+        // to the grant does not put it into the code's scopes and so does not
+        // make a refresh token issuable; it only lets the grant carry the scope
+        // for a client allowed it. See docs/refresh-token-authorization.md.
         if (client.availableScopes.includes('offline_access')) {
-            // TODO: figure out why offline_access is stripped from missingOIDCScope.
             grant.addOIDCScope('offline_access')
         }
         grant.addOIDCScope(prompt.details.missingOIDCScope.join(' '));

--- a/test/integration/offline-access.test.js
+++ b/test/integration/offline-access.test.js
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import request from 'supertest'
+import { createHash, randomBytes } from 'node:crypto'
+
+vi.mock('../../src/adapters/kubernetes.js', () => import('../fakes/shared-kube.js'))
+vi.mock('../../src/adapters/email.js', () => import('../fakes/email-capture.js'))
+
+import { fakeKube } from '../fakes/shared-kube.js'
+import { sentEmails } from '../fakes/email-capture.js'
+
+// What oidc-provider does to offline_access, pinned as behaviour rather than
+// left as a question in a TODO. Its authorization `scopes.js` drops the scope
+// unless the response type returns a code, the client is allowed the
+// refresh_token grant, and the request carries prompt=consent (OIDC Core §11).
+//
+// Passmower's own rule sits on top: a refresh token goes to any client allowed
+// the refresh_token grant, whether or not the scope survived (#243). Pinning
+// both here means an oidc-provider upgrade that changes the scope rules fails
+// loudly rather than quietly reshaping refresh behaviour.
+const REDIRECT = 'https://rp.test/callback'
+const SECRET = 'rp-secret'
+
+const client = (clientId, {grantTypes, availableScopes}) => ({
+    client_id: clientId,
+    client_secret: SECRET,
+    redirect_uris: [REDIRECT],
+    grant_types: grantTypes,
+    response_types: ['code'],
+    token_endpoint_auth_method: 'client_secret_basic',
+    availableScopes,
+    allowedGroups: [],
+    allowedCORSOrigins: [],
+})
+
+const base64url = (buf) => buf.toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+describe('offline_access and refresh tokens (HTTP)', () => {
+    let callback
+
+    beforeAll(async () => {
+        process.env.REDIS_URI ??= 'redis://127.0.0.1:6379'
+        process.env.EMAIL_ENABLED = 'true'
+        globalThis.logger = { debug() {}, info() {}, warn() {}, error() {}, trace() {} }
+        const { buildProvider } = await import('../../src/app.js')
+        callback = (await buildProvider()).callback()
+
+        const { default: RedisAdapter } = await import('../../src/adapters/redis.js')
+        const clients = new RedisAdapter('Client')
+        await clients.upsert('refreshable', client('refreshable', {
+            grantTypes: ['authorization_code', 'refresh_token'],
+            availableScopes: ['openid', 'offline_access'],
+        }))
+        await clients.upsert('no-available-scope', client('no-available-scope', {
+            grantTypes: ['authorization_code', 'refresh_token'],
+            availableScopes: ['openid'],
+        }))
+        await clients.upsert('no-refresh-grant', client('no-refresh-grant', {
+            grantTypes: ['authorization_code'],
+            availableScopes: ['openid', 'offline_access'],
+        }))
+    })
+
+    afterAll(async () => {
+        const { disconnect } = await import('../../src/adapters/redis.js')
+        await disconnect()
+    })
+
+    beforeEach(() => {
+        fakeKube.store.clear()
+        sentEmails.length = 0
+        fakeKube.seed('OIDCUser', {
+            metadata: { name: 'testuser', labels: {} },
+            spec: { email: 'test@example.com', name: 'Test User', groups: [] },
+            passmower: { email: 'test@example.com' },
+            status: {
+                primaryEmail: 'test@example.com', emails: ['test@example.com'], groups: [],
+                profile: { name: 'Test User' }, conditions: [],
+                termsOfService: { acceptedAt: '2026-08-06T12:00:00.000Z', contentHash: 'hash' },
+            },
+        })
+    })
+
+    const jar = () => new Map()
+    const cookieHeader = (j) => [...j.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+    function store(j, res) {
+        for (const c of res.headers['set-cookie'] ?? []) {
+            const pair = c.split(';')[0]
+            const i = pair.indexOf('=')
+            const val = pair.slice(i + 1)
+            if (val === '') j.delete(pair.slice(0, i).trim())
+            else j.set(pair.slice(0, i).trim(), val)
+        }
+    }
+    async function req(j, method, path, form) {
+        let r = request(callback)[method](path).set('Cookie', cookieHeader(j))
+        if (form) r = r.type('form').send(form)
+        const res = await r
+        store(j, res)
+        return res
+    }
+    async function follow(j, res, maxHops = 14) {
+        let cur = res
+        for (let i = 0; i < maxHops && cur.status >= 300 && cur.status < 400; i++) {
+            const loc = cur.headers.location
+            if (!loc) break
+            const u = loc.startsWith('http') ? new URL(loc) : new URL(loc, process.env.ISSUER_URL)
+            if (u.host === new URL(REDIRECT).host) return cur
+            cur = await req(j, 'get', u.pathname + u.search)
+        }
+        return cur
+    }
+
+    // Sign in with the magic link and exchange the code, returning what the
+    // token endpoint granted.
+    async function authorize(clientId, extraParams = {}) {
+        // Own mailbox per call: a test that authorizes twice must not pick up
+        // the first flow's (already used) magic link.
+        sentEmails.length = 0
+        const j = jar()
+        const verifier = base64url(randomBytes(32))
+        const query = new URLSearchParams({
+            client_id: clientId,
+            redirect_uri: REDIRECT,
+            response_type: 'code',
+            scope: 'openid offline_access',
+            state: 'state-243',
+            code_challenge: base64url(createHash('sha256').update(verifier).digest()),
+            code_challenge_method: 'S256',
+            ...extraParams,
+        })
+
+        let res = await follow(j, await req(j, 'get', `/auth?${query}`))
+        const uid = (res.headers.location ?? res.request.url).match(/\/interaction\/([^/?]+)/)[1]
+        await req(j, 'post', `/interaction/${uid}/email`, { email: 'test@example.com' })
+        const link = sentEmails.at(-1).html.match(/\/interaction\/[^/]+\/verify-email\/[0-9a-f-]+/)[0]
+        const final = await follow(j, await req(j, 'get', link))
+        const code = new URL(final.headers.location).searchParams.get('code')
+
+        const tokens = await request(callback)
+            .post('/token')
+            .auth(clientId, SECRET)
+            .type('form')
+            .send({
+                grant_type: 'authorization_code', code,
+                redirect_uri: REDIRECT, code_verifier: verifier,
+            })
+            .expect(200)
+
+        return {
+            scopes: (tokens.body.scope ?? '').split(' ').filter(Boolean),
+            refreshToken: tokens.body.refresh_token,
+        }
+    }
+
+    it('drops offline_access from a request without prompt=consent', async () => {
+        const granted = await authorize('refreshable')
+
+        // Asking for the scope is not enough — this is the condition that
+        // catches people, and it holds even for a client that lists
+        // offline_access in availableScopes.
+        expect(granted.scopes).not.toContain('offline_access')
+        expect(granted.scopes).toContain('openid')
+    })
+
+    it('keeps offline_access when the request carries prompt=consent', async () => {
+        const granted = await authorize('refreshable', { prompt: 'consent' })
+
+        expect(granted.scopes).toContain('offline_access')
+    })
+
+    it('does not depend on availableScopes listing offline_access', async () => {
+        // availableScopes populates the generated Secret and lets the grant
+        // carry the scope; it does not gate what the request may ask for, so
+        // pairing grantTypes with availableScopes is not what decides this.
+        const granted = await authorize('no-available-scope', { prompt: 'consent' })
+
+        expect(granted.scopes).toContain('offline_access')
+    })
+
+    it('drops offline_access for a client not allowed the refresh_token grant', async () => {
+        const granted = await authorize('no-refresh-grant', { prompt: 'consent' })
+
+        expect(granted.scopes).not.toContain('offline_access')
+    })
+
+    it('issues a refresh token to a client allowed the grant, with or without the scope', async () => {
+        // Renewal within the session does not need the offline_access ceremony;
+        // see configuration.js issueRefreshToken.
+        expect((await authorize('refreshable')).refreshToken).toBeTruthy()
+        expect((await authorize('refreshable', { prompt: 'consent' })).refreshToken).toBeTruthy()
+    })
+
+    it('withholds one from a client not allowed the grant', async () => {
+        // It used to be handed one the token endpoint then refused with
+        // "requested grant type is not allowed for this client".
+        expect((await authorize('no-refresh-grant', { prompt: 'consent' })).refreshToken)
+            .toBeUndefined()
+    })
+})

--- a/test/unit/issue-refresh-token.test.js
+++ b/test/unit/issue-refresh-token.test.js
@@ -1,0 +1,53 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import configuration from '../../src/configuration.js'
+
+// A refresh token goes to any client allowed the refresh_token grant, whether or
+// not offline_access was granted — these tokens expire with the session, so they
+// are renewal rather than offline access (#243). The grant-type half is what
+// stops a client being handed a token the token endpoint refuses.
+describe('issueRefreshToken', () => {
+    const code = (scopes) => ({scopes: new Set(scopes)})
+    const client = (grants) => ({
+        clientId: 'apps.grafana',
+        grantTypeAllowed: (grant) => grants.includes(grant),
+    })
+    const ctx = (scope) => ({headers: {}, oidc: {params: scope ? {scope} : {}}})
+
+    beforeEach(() => {
+        globalThis.logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn()}
+    })
+
+    it('issues to a client allowed the grant, with or without offline_access', async () => {
+        const allowed = client(['authorization_code', 'refresh_token'])
+
+        await expect(configuration.issueRefreshToken(ctx('openid'), allowed, code(['openid'])))
+            .resolves.toBe(true)
+        await expect(configuration.issueRefreshToken(
+            ctx('openid offline_access'), allowed, code(['openid', 'offline_access'])))
+            .resolves.toBe(true)
+    })
+
+    it('withholds from a client not allowed the grant', async () => {
+        await expect(configuration.issueRefreshToken(
+            ctx('openid'), client(['authorization_code']), code(['openid'])))
+            .resolves.toBe(false)
+    })
+
+    it('reports the mismatch when such a client asked for offline access', async () => {
+        await configuration.issueRefreshToken(
+            ctx('openid offline_access'), client(['authorization_code']), code(['openid']))
+
+        expect(globalThis.logger.info).toHaveBeenCalledWith(
+            expect.objectContaining({clientId: 'apps.grafana'}),
+            expect.stringContaining('not allowed the refresh_token grant'),
+        )
+    })
+
+    it('stays quiet for a client that never asked for offline access', async () => {
+        // Most clients never want renewal; withholding is not news.
+        await configuration.issueRefreshToken(
+            ctx('openid'), client(['authorization_code']), code(['openid']))
+
+        expect(globalThis.logger.info).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Fixes #243 (needs closing by hand — PRs into `develop` don't auto-close).

You were right to push back: there was something to fix. The two halves of `oidc-provider`'s default condition turn out to be different animals, and only one of them is a bug.

## The bug: a dead credential

A client **without** `refresh_token` in `grantTypes` was issued a refresh token anyway. Verified against a real flow that it cannot be redeemed:

```
POST /token  grant_type=refresh_token
→ 400 {"error":"invalid_request",
       "error_description":"requested grant type is not allowed for this client"}
```

So Passmower handed out a credential the token endpoint refuses. `issueRefreshToken` now gates on `client.grantTypeAllowed('refresh_token')`, and when such a client's application *asked* for `offline_access`, the mismatch is logged — otherwise it's silent, since sign-in succeeds and only renewal is missing:

```
Refresh token withheld: client is not allowed the refresh_token grant
  clientId: apps.grafana
```

## Not adopted: the offline_access half, deliberately

`code.scopes.has('offline_access')` is a policy choice, not a correctness one, and I've left it out on purpose:

- **These tokens are not offline access.** `expiresWithSession` (right above the hook) ends every token with the session, so they only renew silently while the user is still signed in. OIDC Core §11 ties `offline_access` to `prompt=consent` because it governs access *while the user is away* — which Passmower doesn't grant to anyone today.
- **Requiring the ceremony would cost renewal and buy nothing** — it would take refresh from every client whose relying party doesn't send `prompt=consent`, which is most of them.
- `issueRefreshToken` is a first-class configuration hook in `oidc-provider` (`helpers/defaults.js`), so overriding it is a supported customization rather than a deviation to be repaid.

That's a decision rather than a discovery, so it's stated in the code and the doc instead of left implicit — say the word if you'd rather be spec-strict and require the prompt.

## Blast radius: none for documented clients

The README example and both `examples/*.yaml` already list `refresh_token` in `grantTypes`, so clients written against the docs keep their refresh tokens — the existing `email-login` integration test, whose RP declares the grant, still passes unchanged including its refresh exchange. Passmower's own internal client is `implicit`-only and never reaches this hook. What stops is issuing tokens that never worked.

## The TODOs, answered

`offline_access` is removed upstream by `oidc-provider`'s authorization `scopes.js` unless the response type returns a code, the client is allowed the grant, **and** the request carries `prompt=consent`. Traced through four real authorizations rather than guessed — the prompt is what decides it:

| client / request | granted scope |
|---|---|
| `offline_access` in `availableScopes`, no `prompt` | `openid` |
| same, **`prompt=consent`** | `offline_access openid` |
| `offline_access` **not** in `availableScopes`, `prompt=consent` | `openid offline_access` |
| `refresh_token` **not** in `grantTypes`, `prompt=consent` | `openid` |

Row 3 corrects the issue's premise: **`spec.availableScopes` is not involved.** Passmower never sets `client.scope`, so nothing restricts requested scopes to it — it only populates `OIDC_AVAILABLE_SCOPES` in the generated Secret and lets the grant carry the scope. Validating `grantTypes` against `availableScopes` would have enshrined a requirement that doesn't exist.

## Tests and docs

`test/integration/offline-access.test.js` (6) pins both Passmower's rule (issued with the grant, withheld without) and all four scope rows, so an `oidc-provider` upgrade that changes either fails loudly. `test/unit/issue-refresh-token.test.js` (4) covers the condition and that the log stays quiet for clients that never asked.

`docs/refresh-token-authorization.md` now leads with the one requirement, explains why the scope isn't part of it, and separates where `offline_access` does and doesn't matter.

Suites: unit 68 files / 351 tests, integration 12 files / 57 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)