### PR TITLE
feat: enroll applications from Ingress annotations (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,8 +245,10 @@ The chart maps `values.passmower.*` to env vars. The ones that matter most:
 | `ENROLL_USERS`, `USERNAME_SOURCE`, `REQUIRE_CUSTOM_USERNAME`, `USE_GITHUB_USERNAME` | Enrollment / username policy (see `docs/username-configuration.md`). |
 | `PREFERRED_EMAIL_DOMAIN`, `NORMALIZE_EMAIL_ADDRESSES` | Email handling. |
 | `NAMESPACE_SELECTOR` | Which namespaces to watch for client CRDs. |
+| `INGRESS_DISCOVERY_ENABLED` | Derive `OIDCClient`s from `codemowers.io/oidc-*` Ingress annotations (off by default; needs Ingress read). |
 | `DISABLE_FRONTEND_EDIT` | Enforce GitOps (no profile/admin edits). |
 | `KUBERNETES_SERVICE_HOST`, `POD_NAMESPACE` | Set in-cluster; switch kubeconfig/namespace behaviour. |
 
 See also: `README.md` (install + upstream config), `docs/application-listing.md`,
-`docs/claim-mappings.md`, `docs/username-configuration.md`.
+`docs/claim-mappings.md`, `docs/ingress-discovery.md`,
+`docs/username-configuration.md`.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,14 @@ spec:
 Both `labels` and `annotations` are optional and are reconciled onto the secret
 on every change to the `OIDCClient`.
 
+### Enrolling from Ingress annotations
+
+An application that already declares its hostname and path in an `Ingress` can
+be enrolled from `codemowers.io/oidc-*` annotations on it instead of a
+hand-written `OIDCClient` — Passmower derives the client, owned by that Ingress,
+and reconciles it as usual. Off by default; see
+[docs/ingress-discovery.md](docs/ingress-discovery.md).
+
 ## Listing a user's applications
 
 Dashboards, launchers and shared navbars can fetch the applications a signed-in

--- a/charts/passmower/templates/deployment.yaml
+++ b/charts/passmower/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ .Values.passmower.enrollUsers | quote }}
             - name: DISABLE_FRONTEND_EDIT
               value: {{ .Values.passmower.disableFrontendEdit | quote }}
+            - name: INGRESS_DISCOVERY_ENABLED
+              value: {{ .Values.passmower.ingressDiscovery.enabled | quote }}
             {{- with .Values.passmower.namespaceSelector }}
             - name: NAMESPACE_SELECTOR
               value: {{ . | quote }}

--- a/charts/passmower/templates/serviceaccount.yaml
+++ b/charts/passmower/templates/serviceaccount.yaml
@@ -19,6 +19,7 @@ rules:
       - create
       - update
       - patch
+      - delete
     apiGroups:
       - codemowers.cloud
     resources:
@@ -64,6 +65,16 @@ rules:
       - traefik.io
     resources:
       - middlewares
+{{- if .Values.passmower.ingressDiscovery.enabled }}
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -39,6 +39,14 @@ passmower:
   usernameSource: prompt
   # Allow enrolling new users automatically. Actual access will be based on requiredGroup parameter. Disable to only manually provision users.
   enrollUsers: true
+  # Enroll applications from `codemowers.io/oidc-*` annotations on Ingresses, in
+  # addition to hand-written OIDCClient resources. An annotated Ingress gets an
+  # OIDCClient owned by it, which the client operator then reconciles as usual;
+  # removing the Ingress removes the client with it. Off by default because it
+  # creates resources and needs cluster-wide read on Ingresses, which the chart
+  # only grants when this is on. See docs/ingress-discovery.md.
+  ingressDiscovery:
+    enabled: false
   # Disable making changes to users on their profile or via admin panel - use for enforcing GitOps practices via OIDCUser spec.
   disableFrontendEdit: false
   # Comma-separated, wildcard enabled namespace selector to select, in which namespaces Passmower looks for client CRDs.

--- a/docs/ingress-discovery.md
+++ b/docs/ingress-discovery.md
@@ -1,0 +1,128 @@
+# Enrolling applications from Ingress annotations
+
+Applications are normally enrolled by writing an `OIDCClient`. Passmower can
+also derive one from annotations on an `Ingress`, the way Traefik and
+external-dns are configured, so an application that already declares its
+hostname and path in an Ingress does not have to repeat them.
+
+Off by default, because it creates resources and needs cluster read on
+Ingresses, which the chart grants only when it is on:
+
+```yaml
+passmower:
+  ingressDiscovery:
+    enabled: true
+```
+
+## Annotating an Ingress
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: apps
+  annotations:
+    codemowers.io/oidc-display-name: Grafana
+    codemowers.io/oidc-redirect-path: /login/generic_oauth
+    codemowers.io/oidc-allowed-groups: k-space:floor,k-space:foobar
+spec:
+  rules:
+    - host: grafana.example.com
+      http:
+        paths: [...]
+```
+
+Passmower creates an `OIDCClient` named after the Ingress, in the same
+namespace, owned by it:
+
+```yaml
+apiVersion: codemowers.cloud/v1
+kind: OIDCClient
+metadata:
+  name: grafana
+  namespace: apps
+  labels:
+    app.kubernetes.io/managed-by: passmower
+    codemowers.cloud/discovered-from: Ingress.grafana
+  ownerReferences:
+    - apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      name: grafana
+spec:
+  displayName: Grafana
+  uri: https://grafana.example.com/
+  redirectUris:
+    - https://grafana.example.com/login/generic_oauth
+  grantTypes: ['authorization_code']
+  responseTypes: ['code']
+  availableScopes: ['openid']
+  allowedGroups: ['k-space:floor', 'k-space:foobar']
+```
+
+From there nothing is special: the client operator generates the Secret,
+registers the client, reports `Ready`, and lists the application in the
+launcher exactly as it does for a hand-written one. The generated resource is
+also the answer to "what did discovery actually make?" — read it with
+`kubectl get oidcclient`.
+
+## Annotations
+
+| Annotation | Maps to | Default |
+|---|---|---|
+| `codemowers.io/oidc-redirect-path` | `redirectUris`, resolved against the host | **required** |
+| `codemowers.io/oidc-display-name` | `displayName` | the Ingress name |
+| `codemowers.io/oidc-allowed-groups` | `allowedGroups` | unset (everyone) |
+| `codemowers.io/oidc-allowed-users` | `allowedUsers` | unset |
+| `codemowers.io/oidc-available-scopes` | `availableScopes` | `openid` |
+| `codemowers.io/oidc-grant-types` | `grantTypes` | `authorization_code` |
+| `codemowers.io/oidc-response-types` | `responseTypes` | `code` |
+
+All list-valued annotations are comma-separated. `uri` comes from the Ingress
+host, so it is never annotated.
+
+## Rules
+
+- **Any `codemowers.io/oidc-*` annotation asks for discovery.** Keying off the
+  whole prefix rather than one required annotation means a mistyped annotation
+  gets a complaint on the Ingress instead of doing nothing quietly.
+- **One host.** An Ingress with several hosts in `spec.rules` is refused rather
+  than resolved — which host an application authenticates on is not a good thing
+  to guess at. Split it, or write the `OIDCClient` by hand.
+- **A hand-written client wins.** If an `OIDCClient` of that name already exists
+  and did not come from this Ingress, it is left untouched and the conflict is
+  reported. The resource in Git is authoritative; an annotation does not rewrite
+  it from the side.
+- **Removing the annotations removes the client.** Deleting the Ingress does too,
+  through the ownerReference.
+- **`NAMESPACE_SELECTOR` applies**, exactly as it does to `OIDCClient`
+  resources: without it, only Ingresses in Passmower's own namespace are seen.
+
+## What it reports
+
+Everything discovery decides shows up as an event on the Ingress, which is
+where whoever wrote the annotation will look:
+
+```console
+$ kubectl describe ingress grafana
+...
+Events:
+  Type     Reason                    Message
+  Normal   OIDCClientDiscovered      Created OIDCClient grafana for https://grafana.example.com/
+```
+
+| Reason | Meaning |
+|---|---|
+| `OIDCClientDiscovered` | client created or updated from the annotations |
+| `OIDCClientRemoved` | annotations gone, generated client withdrawn |
+| `OIDCClientConflict` | a client of that name exists and is not ours to manage |
+| `IngressDiscoveryFailed` | the annotations do not describe a client — the message says why |
+
+## When to write the OIDCClient instead
+
+Discovery covers the common shape: one host, one or more redirect paths, group
+or user allowlists. Anything else — `secretRefreshJobSpec`, `claimMappings`,
+`allowedCORSOrigins`, `pkce`, `displayOrder`, a client whose redirect URI is not
+on its own Ingress host, or a native application with a custom-scheme redirect —
+is a reason to write the `OIDCClient` directly. The two can coexist in one
+cluster; they are the same resource in the end.

--- a/src/adapters/kubernetes.js
+++ b/src/adapters/kubernetes.js
@@ -146,6 +146,22 @@ export class KubernetesAdapter {
         })
     }
 
+    async deleteNamespacedCustomObject(kind, namespace, id, apiGroup = defaultApiGroup, apiGroupVersion = defaultApiGroupVersion) {
+        return await this.customObjectsApi.deleteNamespacedCustomObject({
+            group: apiGroup,
+            version: apiGroupVersion,
+            namespace,
+            plural: plurals[kind],
+            name: id
+        }, this.defaultOptions).then(() => true).catch((e) => {
+            if (e.code === 404) {
+                return true // already gone; the caller wanted it absent
+            }
+            globalThis.logger.error(e)
+            return false
+        })
+    }
+
     async patchNamespacedCustomObject(kind, namespace, id, values, existingValues, mapperFunction, apiGroup = defaultApiGroup, apiGroupVersion = defaultApiGroupVersion) {
         const delta = diff(existingValues, values)
         const patches = format(delta);

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,7 @@ import {validateEmailConfiguration} from './utils/email-configuration.js';
 import {validateGroupConfiguration} from './utils/group-configuration.js';
 import {getActivityTracker} from './services/activity-tracker.js';
 import KubeOidcUserEventHookOperator from './operators/kube-oidc-user-event-hook-operator.js';
+import {KubeIngressDiscoveryOperator} from "./operators/kube-ingress-discovery-operator.js";
 
 const __dirname = dirname(import.meta.url);
 
@@ -60,6 +61,12 @@ export async function startOperators(provider) {
     await kubeUserEventHookOperator.watchUsers()
     const scimConnectionOperator = new KubeScimConnectionOperator()
     await scimConnectionOperator.watchConnections()
+    // Opt-in: discovery creates OIDCClient resources from annotations on any
+    // Ingress it can read, so an installation says when it wants that.
+    if (process.env.INGRESS_DISCOVERY_ENABLED === 'true') {
+        const ingressDiscoveryOperator = new KubeIngressDiscoveryOperator()
+        await ingressDiscoveryOperator.watchIngresses()
+    }
     activityTracker.start()
 }
 

--- a/src/operators/kube-ingress-discovery-operator.js
+++ b/src/operators/kube-ingress-discovery-operator.js
@@ -1,0 +1,155 @@
+import {KubernetesAdapter} from "../adapters/kubernetes.js";
+import {
+    IngressApiGroup,
+    IngressApiGroupVersion,
+    IngressCrd,
+    OIDCClientCrd,
+} from "../utils/kubernetes/kube-constants.js";
+import {KubeOwnerMetadata} from "../utils/kubernetes/kube-owner-metadata.js";
+import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
+import {
+    discoveredClientLabels,
+    discoveryProblems,
+    isDiscoveredFrom,
+    oidcClientSpecFor,
+    requestsDiscovery,
+} from "../utils/kubernetes/ingress-oidc-client.js";
+
+// Enrolls applications from Ingress annotations (#35): an annotated Ingress
+// gets an OIDCClient, owned by that Ingress, and the client operator takes it
+// from there. Discovery only ever materialises a resource — it does not talk to
+// Redis or issue secrets — so there is one client code path, an `OIDCClient` the
+// operator can inspect for what was discovered, and no orphan to clean up when
+// the Ingress goes away, because ownerReferences collect it.
+export class KubeIngressDiscoveryOperator {
+    constructor(adapter = new KubernetesAdapter()) {
+        this.adapter = adapter
+        this.namespaceFilter = new NamespaceFilter(this.adapter.namespace)
+    }
+
+    async watchIngresses() {
+        this.adapter.setWatchParameters(
+            IngressCrd,
+            (ingress) => ingress,
+            (ingress) => this.#reconcile(ingress),
+            (ingress) => this.#reconcile(ingress),
+            // An Ingress being deleted takes its generated client with it
+            // through the ownerReference, so there is nothing to do here.
+            () => undefined,
+            this.namespaceFilter,
+            IngressApiGroup,
+            IngressApiGroupVersion,
+        )
+        await this.adapter.watchObjects()
+    }
+
+    async #reconcile(ingress) {
+        const namespace = ingress?.metadata?.namespace
+        const name = ingress?.metadata?.name
+        if (!namespace || !name) {
+            return
+        }
+        try {
+            const existing = await this.adapter.getNamespacedCustomObject(
+                OIDCClientCrd, namespace, name, (client) => client)
+
+            if (!requestsDiscovery(ingress)) {
+                // Annotations removed: withdraw what we generated, and never
+                // touch a client we did not.
+                if (existing && isDiscoveredFrom(existing, ingress)) {
+                    await this.adapter.deleteNamespacedCustomObject(OIDCClientCrd, namespace, name)
+                    await this.#event(ingress, 'OIDCClientRemoved',
+                        `Removed generated OIDCClient ${name}: no ${'codemowers.io/oidc-*'} annotations remain`,
+                        'Normal')
+                }
+                return
+            }
+
+            if (existing && !isDiscoveredFrom(existing, ingress)) {
+                // A hand-written client of the same name is authoritative: the
+                // resource in Git wins over an annotation, and quietly patching
+                // it from an Ingress would be the wrong way round.
+                await this.#event(ingress, 'OIDCClientConflict',
+                    `OIDCClient ${name} already exists and was not discovered from this Ingress; not modifying it`)
+                return
+            }
+
+            const problems = discoveryProblems(ingress)
+            if (problems.length) {
+                await this.#event(ingress, 'IngressDiscoveryFailed',
+                    `Cannot derive an OIDCClient: ${problems.join('; ')}`)
+                return
+            }
+
+            const spec = oidcClientSpecFor(ingress)
+            if (existing) {
+                await this.#patchClient(ingress, existing, spec)
+                return
+            }
+            await this.#createClient(ingress, spec)
+        } catch (error) {
+            globalThis.logger?.error({error, ingress: `${namespace}/${name}`},
+                'Failed to reconcile Ingress into an OIDCClient')
+        }
+    }
+
+    async #createClient(ingress, spec) {
+        const {namespace, name} = ingress.metadata
+        const created = await this.adapter.createNamespacedCustomObject(
+            OIDCClientCrd,
+            namespace,
+            name,
+            {spec},
+            (client) => client,
+            new KubeOwnerMetadata(
+                IngressCrd, name, ingress.metadata.uid, IngressApiGroup, IngressApiGroupVersion),
+            discoveredClientLabels(ingress),
+        )
+        if (!created) {
+            await this.#event(ingress, 'IngressDiscoveryFailed',
+                `Failed to create OIDCClient ${name}`)
+            return
+        }
+        await this.#event(ingress, 'OIDCClientDiscovered',
+            `Created OIDCClient ${name} for ${spec.uri}`, 'Normal')
+    }
+
+    async #patchClient(ingress, existing, spec) {
+        const {namespace, name} = ingress.metadata
+        // Only the fields the annotations describe: anything else on the
+        // generated client — including status — is left as it is.
+        const desired = {...existing.spec, ...spec}
+        if (JSON.stringify(desired) === JSON.stringify(existing.spec)) {
+            return
+        }
+        const patched = await this.adapter.patchNamespacedCustomObject(
+            OIDCClientCrd,
+            namespace,
+            name,
+            {spec: desired},
+            {spec: existing.spec},
+            (client) => client,
+        )
+        if (!patched) {
+            await this.#event(ingress, 'IngressDiscoveryFailed',
+                `Failed to update OIDCClient ${name}`)
+            return
+        }
+        await this.#event(ingress, 'OIDCClientDiscovered',
+            `Updated OIDCClient ${name} for ${spec.uri}`, 'Normal')
+    }
+
+    // Events land on the Ingress, which is where somebody who wrote an
+    // annotation goes looking.
+    async #event(ingress, reason, message, type = 'Warning') {
+        await this.adapter.createEvent(
+            ingress.metadata.namespace,
+            new KubeOwnerMetadata(
+                IngressCrd, ingress.metadata.name, ingress.metadata.uid,
+                IngressApiGroup, IngressApiGroupVersion),
+            reason,
+            message,
+            type,
+        )
+    }
+}

--- a/src/utils/kubernetes/ingress-oidc-client.js
+++ b/src/utils/kubernetes/ingress-oidc-client.js
@@ -1,0 +1,91 @@
+import {OIDCClientCrd} from './kube-constants.js'
+
+// Discovery of applications from Ingress annotations, the way Traefik and
+// external-dns are configured (#35). An annotated Ingress is turned into an
+// OIDCClient owned by that Ingress, and from there the existing client operator
+// does everything it already does — generate the Secret, register the client,
+// report status, list it in the launcher. There is only one client code path,
+// and deleting the Ingress garbage-collects the client with it.
+export const ANNOTATION_PREFIX = 'codemowers.io/oidc-'
+export const annotation = (suffix) => `${ANNOTATION_PREFIX}${suffix}`
+
+// The label that marks a generated client as ours to manage. A client without it
+// is somebody's hand-written resource and is never touched.
+export const DISCOVERED_BY_LABEL = 'codemowers.cloud/discovered-from'
+
+const list = (value) => (value ?? '').split(',').map(v => v.trim()).filter(Boolean)
+
+const annotationsOf = (ingress) => ingress?.metadata?.annotations ?? {}
+
+// Any codemowers.io/oidc-* annotation asks for discovery. Keying off the whole
+// prefix rather than one required annotation means a typo still gets a
+// complaint on the resource instead of silently doing nothing.
+export const requestsDiscovery = (ingress) =>
+    Object.keys(annotationsOf(ingress)).some(key => key.startsWith(ANNOTATION_PREFIX))
+
+// Hosts an Ingress serves, in rule order.
+export const hostsOf = (ingress) =>
+    (ingress?.spec?.rules ?? []).map(rule => rule.host).filter(Boolean)
+
+// What cannot be turned into a client, phrased for an event on the Ingress.
+export const discoveryProblems = (ingress) => {
+    const problems = []
+    const hosts = hostsOf(ingress)
+    if (!hosts.length) {
+        problems.push('no host in spec.rules to build a redirect URI from')
+    } else if (hosts.length > 1) {
+        // One client has one uri; picking a host for the operator would be a
+        // guess, and guessing which host an application authenticates on is
+        // not a good failure mode.
+        problems.push(`${hosts.length} hosts in spec.rules; discovery supports one (${hosts.join(', ')})`)
+    }
+    if (!list(annotationsOf(ingress)[annotation('redirect-path')]).length) {
+        problems.push(`${annotation('redirect-path')} is required`)
+    }
+    return problems
+}
+
+// The OIDCClient spec an annotated Ingress describes. Only the annotations that
+// have no sensible default are required; everything else follows the CRD's own
+// defaults so the generated resource stays as small as what was asked for.
+export const oidcClientSpecFor = (ingress) => {
+    const annotations = annotationsOf(ingress)
+    const host = hostsOf(ingress)[0]
+    const paths = list(annotations[annotation('redirect-path')])
+    const spec = {
+        displayName: annotations[annotation('display-name')] ?? ingress.metadata.name,
+        uri: `https://${host}/`,
+        redirectUris: paths.map(path => new URL(path, `https://${host}`).href),
+        grantTypes: list(annotations[annotation('grant-types')]).length
+            ? list(annotations[annotation('grant-types')])
+            : ['authorization_code'],
+        responseTypes: list(annotations[annotation('response-types')]).length
+            ? list(annotations[annotation('response-types')])
+            : ['code'],
+        availableScopes: list(annotations[annotation('available-scopes')]).length
+            ? list(annotations[annotation('available-scopes')])
+            : ['openid'],
+    }
+    const allowedGroups = list(annotations[annotation('allowed-groups')])
+    if (allowedGroups.length) {
+        spec.allowedGroups = allowedGroups
+    }
+    const allowedUsers = list(annotations[annotation('allowed-users')])
+    if (allowedUsers.length) {
+        spec.allowedUsers = allowedUsers
+    }
+    return spec
+}
+
+export const discoveredClientLabels = (ingress) => ({
+    'app.kubernetes.io/managed-by': 'passmower',
+    [DISCOVERED_BY_LABEL]: `Ingress.${ingress.metadata.name}`,
+})
+
+// Ours to manage only if this exact Ingress produced it. Anything else — a
+// hand-written client, or one discovered from a different Ingress that happens
+// to share the name — is left alone.
+export const isDiscoveredFrom = (client, ingress) =>
+    client?.metadata?.labels?.[DISCOVERED_BY_LABEL] === `Ingress.${ingress.metadata.name}`
+
+export const discoveredClientKind = OIDCClientCrd

--- a/src/utils/kubernetes/kube-constants.js
+++ b/src/utils/kubernetes/kube-constants.js
@@ -46,7 +46,13 @@ export const TraefikMiddlewareApiGroup = 'traefik.io'
 export const TraefikMiddlewareApiGroupVersion = 'v1alpha1'
 export const TraefikMiddlewareForwardAuthAddress = (deployment, namespace, clientId) => `http://${deployment}.${namespace}.svc.cluster.local/forward-auth?client=${clientId}`
 
+export const IngressCrd = 'Ingress'
+export const Ingresses = 'ingresses'
+export const IngressApiGroup = 'networking.k8s.io'
+export const IngressApiGroupVersion = 'v1'
+
 export const plurals = {
+    [IngressCrd]: Ingresses,
     [OIDCUserCrd]: OIDCUsers,
     [OIDCUserEventHookCrd]: OIDCUserEventHooks,
     [OIDCClientCrd]: OIDCClients,

--- a/test/fakes/fake-kubernetes-adapter.js
+++ b/test/fakes/fake-kubernetes-adapter.js
@@ -40,19 +40,33 @@ export class FakeKubernetesAdapter {
         return mapperFunction(structuredClone(stored))
     }
 
-    async createNamespacedCustomObject(kind, _namespace, name, spec, mapperFunction, _owner, labels = {}) {
+    async createNamespacedCustomObject(kind, _namespace, name, spec, mapperFunction, owner, labels = {}) {
         const key = this.#key(kind, name)
         if (this.store.has(key)) return null // name already taken -> real adapter swallows the conflict
         const obj = {
             apiVersion: 'codemowers.cloud/v1',
             kind,
-            metadata: { name, labels, resourceVersion: this.#nextRv(), creationTimestamp: new Date().toISOString() },
+            metadata: {
+                name, labels,
+                // The real adapter turns `owner` into an ownerReference, which is
+                // what garbage-collects generated resources with their parent.
+                ownerReferences: owner ? [structuredClone(owner)] : undefined,
+                resourceVersion: this.#nextRv(),
+                creationTimestamp: new Date().toISOString(),
+            },
             status: {},
             ...structuredClone(spec),
         }
         this.store.set(key, obj)
         this.#emit('ADDED', kind, obj)
         return mapperFunction(structuredClone(obj))
+    }
+
+    async deleteNamespacedCustomObject(kind, _namespace, id) {
+        const key = this.#key(kind, id)
+        const existed = this.store.delete(key)
+        if (existed) this.#emit('DELETED', kind, {kind, metadata: {name: id}})
+        return true // absent either way, as the real adapter reports for a 404
     }
 
     async patchNamespacedCustomObject(kind, _namespace, id, values, _existingValues, mapperFunction) {

--- a/test/unit/ingress-discovery.test.js
+++ b/test/unit/ingress-discovery.test.js
@@ -1,0 +1,207 @@
+import {readFileSync} from 'node:fs'
+import {loadAll} from 'js-yaml'
+import {beforeEach, describe, expect, it} from 'vitest'
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js'
+import {KubeIngressDiscoveryOperator} from '../../src/operators/kube-ingress-discovery-operator.js'
+import {
+    discoveryProblems,
+    oidcClientSpecFor,
+    requestsDiscovery,
+} from '../../src/utils/kubernetes/ingress-oidc-client.js'
+
+const ingress = (annotations, {hosts = ['grafana.example.com'], name = 'grafana'} = {}) => ({
+    metadata: {name, namespace: 'apps', uid: `uid-${name}`, annotations},
+    spec: {rules: hosts.map(host => ({host, http: {paths: []}}))},
+})
+
+// The annotations from the issue, verbatim.
+const REPORTED = {
+    'codemowers.io/oidc-display-name': 'Grafana',
+    'codemowers.io/oidc-redirect-path': '/login/generic_oauth',
+    'codemowers.io/oidc-allowed-groups': 'k-space:floor,k-space:foobar',
+}
+
+describe('reading an Ingress', () => {
+    it('derives a client from the annotations in the report', () => {
+        expect(requestsDiscovery(ingress(REPORTED))).toBe(true)
+        expect(discoveryProblems(ingress(REPORTED))).toEqual([])
+        expect(oidcClientSpecFor(ingress(REPORTED))).toEqual({
+            displayName: 'Grafana',
+            uri: 'https://grafana.example.com/',
+            redirectUris: ['https://grafana.example.com/login/generic_oauth'],
+            grantTypes: ['authorization_code'],
+            responseTypes: ['code'],
+            availableScopes: ['openid'],
+            allowedGroups: ['k-space:floor', 'k-space:foobar'],
+        })
+    })
+
+    it('ignores an Ingress with no oidc annotations', () => {
+        expect(requestsDiscovery(ingress({'kubernetes.io/ingress.class': 'nginx'}))).toBe(false)
+        expect(requestsDiscovery(ingress({}))).toBe(false)
+        expect(requestsDiscovery({metadata: {name: 'x'}})).toBe(false)
+    })
+
+    it('takes the display name from the Ingress when none is annotated', () => {
+        const spec = oidcClientSpecFor(ingress({'codemowers.io/oidc-redirect-path': '/cb'}))
+
+        expect(spec.displayName).toBe('grafana')
+    })
+
+    it('accepts several redirect paths and overridden types and scopes', () => {
+        const spec = oidcClientSpecFor(ingress({
+            'codemowers.io/oidc-redirect-path': '/cb, /auth/callback',
+            'codemowers.io/oidc-available-scopes': 'openid,profile,email',
+            'codemowers.io/oidc-grant-types': 'authorization_code,refresh_token',
+            'codemowers.io/oidc-allowed-users': 'alice,bob',
+        }))
+
+        expect(spec.redirectUris).toEqual([
+            'https://grafana.example.com/cb',
+            'https://grafana.example.com/auth/callback',
+        ])
+        expect(spec.availableScopes).toEqual(['openid', 'profile', 'email'])
+        expect(spec.grantTypes).toEqual(['authorization_code', 'refresh_token'])
+        expect(spec.allowedUsers).toEqual(['alice', 'bob'])
+    })
+
+    it('refuses what it cannot derive rather than guessing', () => {
+        expect(discoveryProblems(ingress({'codemowers.io/oidc-display-name': 'Grafana'})))
+            .toEqual(['codemowers.io/oidc-redirect-path is required'])
+        expect(discoveryProblems(ingress(REPORTED, {hosts: []})))
+            .toContain('no host in spec.rules to build a redirect URI from')
+        // Which host an application authenticates on is not a good thing to
+        // guess at, so several hosts is refused rather than resolved.
+        expect(discoveryProblems(ingress(REPORTED, {hosts: ['a.example.com', 'b.example.com']}))[0])
+            .toMatch(/2 hosts in spec.rules; discovery supports one/)
+    })
+})
+
+describe('discovering an application from an Ingress', () => {
+    let adapter, operator
+
+    const clientOf = (name = 'grafana') => adapter.store.get(`OIDCClient/${name}`)
+    const reconcile = async (obj, type = 'ADDED') => {
+        adapter.watchParameters.namespaceFilter = {filter: () => true, namespace: 'apps'}
+        const callback = type === 'ADDED'
+            ? adapter.watchParameters.addedCallback
+            : adapter.watchParameters.modifiedCallback
+        await callback(obj)
+    }
+
+    beforeEach(async () => {
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        operator = new KubeIngressDiscoveryOperator(adapter)
+        await operator.watchIngresses()
+    })
+
+    it('creates an OIDCClient owned by the Ingress', async () => {
+        await reconcile(ingress(REPORTED))
+
+        const client = clientOf()
+        expect(client.spec.uri).toBe('https://grafana.example.com/')
+        expect(client.spec.allowedGroups).toEqual(['k-space:floor', 'k-space:foobar'])
+        // The ownerReference is what removes the client when the Ingress goes,
+        // so discovery never leaves an orphan behind.
+        expect(client.metadata.ownerReferences).toEqual([expect.objectContaining({
+            kind: 'Ingress', name: 'grafana', uid: 'uid-grafana',
+            apiVersion: 'networking.k8s.io/v1',
+        })])
+        expect(client.metadata.labels['codemowers.cloud/discovered-from']).toBe('Ingress.grafana')
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'OIDCClientDiscovered', type: 'Normal',
+        })])
+    })
+
+    it('updates the client when an annotation changes', async () => {
+        await reconcile(ingress(REPORTED))
+        await reconcile(ingress({...REPORTED, 'codemowers.io/oidc-allowed-groups': 'k-space:floor'}),
+            'MODIFIED')
+
+        expect(clientOf().spec.allowedGroups).toEqual(['k-space:floor'])
+    })
+
+    it('does nothing when nothing changed', async () => {
+        await reconcile(ingress(REPORTED))
+        const before = clientOf().metadata.resourceVersion
+
+        await reconcile(ingress(REPORTED), 'MODIFIED')
+
+        expect(clientOf().metadata.resourceVersion).toBe(before)
+        expect(adapter.events).toHaveLength(1)
+    })
+
+    it('withdraws the client when the annotations are removed', async () => {
+        await reconcile(ingress(REPORTED))
+        expect(clientOf()).toBeDefined()
+
+        await reconcile(ingress({'kubernetes.io/ingress.class': 'nginx'}), 'MODIFIED')
+
+        expect(clientOf()).toBeUndefined()
+        expect(adapter.events.at(-1)).toEqual(expect.objectContaining({reason: 'OIDCClientRemoved'}))
+    })
+
+    it('never touches a hand-written client of the same name', async () => {
+        // The resource in Git is authoritative; an annotation must not rewrite
+        // it from the side.
+        adapter.seed('OIDCClient', {
+            metadata: {name: 'grafana', namespace: 'apps', labels: {}},
+            spec: {uri: 'https://written-by-hand.example.com/', redirectUris: ['https://x/cb'],
+                grantTypes: ['authorization_code'], responseTypes: ['code']},
+            status: {},
+        })
+
+        await reconcile(ingress(REPORTED))
+
+        expect(clientOf().spec.uri).toBe('https://written-by-hand.example.com/')
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'OIDCClientConflict', type: 'Warning',
+        })])
+    })
+
+    it('reports on the Ingress what it could not derive', async () => {
+        await reconcile(ingress(REPORTED, {hosts: ['a.example.com', 'b.example.com']}))
+
+        expect(clientOf()).toBeUndefined()
+        expect(adapter.events).toEqual([expect.objectContaining({
+            reason: 'IngressDiscoveryFailed', type: 'Warning',
+            message: expect.stringContaining('discovery supports one'),
+        })])
+    })
+
+    it('leaves an unannotated Ingress alone entirely', async () => {
+        await reconcile(ingress({'kubernetes.io/ingress.class': 'nginx'}))
+
+        expect(adapter.store.size).toBe(0)
+        expect(adapter.events).toEqual([])
+    })
+})
+
+// A discovered client is written straight to the API server, so every field the
+// mapping produces has to be one the CRD declares — an unknown key is pruned
+// and an invalid enum value is rejected outright, either way leaving an Ingress
+// that looks annotated and an application that cannot sign anyone in.
+describe('the derived spec against the OIDCClient CRD', () => {
+    const crd = loadAll(readFileSync(
+        new URL('../../charts/passmower/templates/crds.yaml', import.meta.url), 'utf8'))
+        .find(doc => doc?.metadata?.name === 'oidcclients.codemowers.cloud')
+
+    it.each(crd.spec.versions.map(version => version.name))('fits %s', (versionName) => {
+        const schema = crd.spec.versions.find(v => v.name === versionName)
+            .schema.openAPIV3Schema.properties.spec
+        const spec = oidcClientSpecFor(ingress({
+            ...REPORTED,
+            'codemowers.io/oidc-available-scopes': 'openid,profile,email',
+            'codemowers.io/oidc-allowed-users': 'alice',
+        }))
+
+        expect(Object.keys(spec).filter(key => !(key in schema.properties))).toEqual([])
+        for (const required of schema.required) {
+            expect(spec[required]).toBeDefined()
+        }
+        for (const field of ['availableScopes', 'grantTypes', 'responseTypes']) {
+            expect(schema.properties[field].items.enum).toEqual(expect.arrayContaining(spec[field]))
+        }
+    })
+})


### PR DESCRIPTION
Implements #35 with the annotation-driven discovery you picked (needs closing by hand — PRs into `develop` don't auto-close). `ingressRef` for the hand-written case is the other half of "both, annotations first" and is not in here.

## Shape

An Ingress carrying `codemowers.io/oidc-*` annotations produces an `OIDCClient`, named after it, in its namespace, **owned by it**:

```yaml
# Ingress — the app team writes only this
metadata:
  annotations:
    codemowers.io/oidc-display-name: Grafana
    codemowers.io/oidc-redirect-path: /login/generic_oauth
    codemowers.io/oidc-allowed-groups: k-space:floor,k-space:foobar
spec:
  rules:
    - host: grafana.example.com
```
```yaml
# OIDCClient — generated, ownerReferences → Ingress/grafana
spec:
  displayName: Grafana
  uri: https://grafana.example.com/
  redirectUris: ['https://grafana.example.com/login/generic_oauth']
  grantTypes: ['authorization_code']
  responseTypes: ['code']
  availableScopes: ['openid']
  allowedGroups: ['k-space:floor', 'k-space:foobar']
```

Discovery only ever materialises that resource — it never touches Redis or issues secrets. So there is **one client code path**, the generated resource is itself the answer to "what did discovery make?" (`kubectl get oidcclient`), and nothing is orphaned when the Ingress goes, because the ownerReference collects it. Your comment's `ingressRef`, or IngressRoute later, is another source feeding the same materialiser.

`uri` and `redirectUris` come from the Ingress host — that's the duplication this removes. Also supported: `allowed-users`, `available-scopes`, `grant-types`, `response-types`.

## Decisions I made, each arguable

- **Any `codemowers.io/oidc-*` annotation asks for discovery**, rather than one designated annotation. A mistyped annotation then gets a complaint on the Ingress instead of doing nothing quietly.
- **Several hosts in `spec.rules` is refused**, as the issue suggested. Which host an application authenticates on isn't a good thing to guess at.
- **A hand-written `OIDCClient` of the same name is never touched**, only reported as `OIDCClientConflict`. The resource in Git is authoritative; an annotation must not rewrite it from the side. Ownership is a `codemowers.cloud/discovered-from` label naming the producing Ingress, so discovery also won't adopt a client that came from a different one.
- **Removing the annotations withdraws the generated client** — which is why the chart's role gains `delete` on `oidcclients`. Deleting the Ingress is handled by GC and needs no permission.
- **Off by default** (`passmower.ingressDiscovery.enabled`). It creates resources and needs cluster-wide read on Ingresses, which the chart grants *only* when enabled — verified that the rendered ClusterRole contains no `ingresses` rule with it off. Happy to flip the default if you'd rather it be on.

Everything discovery decides lands as an event on the Ingress (`OIDCClientDiscovered`, `OIDCClientRemoved`, `OIDCClientConflict`, `IngressDiscoveryFailed`), which is where whoever wrote the annotation looks.

`NAMESPACE_SELECTOR` applies exactly as it does to `OIDCClient` resources: without it, only Ingresses in Passmower's own namespace are seen. Documented rather than special-cased.

## Tests

`test/unit/ingress-discovery.test.js` (14). The mapping is a pure function, tested against **the issue's annotations verbatim**; the operator is driven through the fake adapter for create, update, no-op on no change, withdrawal, the hand-written conflict, the multi-host refusal, and leaving an unannotated Ingress entirely alone.

The last two assert the derived spec **against the real CRD schema** on both served versions — no unknown keys (which the API server would prune), all required fields present, every enum-valued field valid. That's the drift class that bit us in #234 and #237, and here it would leave an Ingress looking annotated with an application that can't sign anyone in.

The fake adapter now records `ownerReferences` and supports deleting custom objects, matching the real one — otherwise the ownership and withdrawal behaviour would have been assumed rather than observed, which is the gap that hid #225 and #236.

Suites: unit 70 files / 369 tests, integration 57. `helm lint` clean, both discovery states rendered and checked.

## Not verified on a cluster

minikube is stopped in this session, so this has not been run against a real API server — the operator is covered against the fake and the generated spec against the parsed CRD schema. Worth a live pass before it ships in 2.4.0; say the word and I'll start minikube and drive a real annotated Ingress through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)