### PR TITLE
chore: bundle Valkey as the session store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:7-alpine
+        # Valkey, as the chart bundles. redis-cli is a symlink in that image, so
+        # the health check reads the same for either implementation.
+        image: valkey/valkey:8-alpine
         ports: ['6379:6379']
         options: >-
           --health-cmd "redis-cli ping" --health-interval 5s

--- a/charts/passmower/templates/redis.yaml
+++ b/charts/passmower/templates/redis.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
         - name: redis
-          image: {{ .Values.redis.internal.image | default "redis:7-alpine" }}
+          image: {{ .Values.redis.internal.image | default "valkey/valkey:8-alpine" }}
           command:
             - redis-server
           env:

--- a/charts/passmower/values.yaml
+++ b/charts/passmower/values.yaml
@@ -240,11 +240,17 @@ redis:
     spec:
       capacity: 100Mi
       class: ephemeral
-  # Deploys a simple, non persistent Redis deployment.
+  # Deploys a simple, non persistent session store.
   internal:
     enabled: true
-    # Image for the internal (non-persistent) Redis. Pinned rather than :latest.
-    image: redis:7-alpine
+    # Image for the internal (non-persistent) store. Pinned rather than :latest.
+    # Valkey by default: it is BSD-licensed, where the redis:7 line is
+    # RSALv2/SSPLv1, and this chart ships as open source. Either works — the
+    # container command stays redis-server, which the Valkey image provides as a
+    # symlink, so setting this back to redis:7-alpine (or redis:8-alpine) needs
+    # no other change. Only the bundled store is affected; redisClaim and
+    # external are untouched.
+    image: valkey/valkey:8-alpine
     # Scheduling for the internal Redis, which holds every session and grant —
     # losing it signs everyone out at once. With neither requests nor limits the
     # pod is BestEffort, which is what a kubelet evicts first under node memory

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,9 @@
 # the host-built frontend and a KUBECONFIG pointing at the test cluster.
 services:
   redis:
-    image: redis:7-alpine
+    # Valkey, as the chart bundles. The redis-server entrypoint is a symlink in
+    # that image, so this line is the same for either implementation.
+    image: valkey/valkey:8-alpine
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "6379:6379"

--- a/test/unit/chart-session-store.test.js
+++ b/test/unit/chart-session-store.test.js
@@ -1,0 +1,40 @@
+import {readFileSync} from 'node:fs'
+import {load} from 'js-yaml'
+import {describe, expect, it} from 'vitest'
+
+const redis = readFileSync(
+    new URL('../../charts/passmower/templates/redis.yaml', import.meta.url), 'utf8')
+const values = load(readFileSync(
+    new URL('../../charts/passmower/values.yaml', import.meta.url), 'utf8'))
+const compose = load(readFileSync(
+    new URL('../../docker-compose.test.yml', import.meta.url), 'utf8'))
+const workflow = load(readFileSync(
+    new URL('../../.github/workflows/test.yml', import.meta.url), 'utf8'))
+
+// The bundled store is Valkey: BSD-licensed, where the redis:7 line is
+// RSALv2/SSPLv1, and this chart ships as open source.
+describe('the bundled session store', () => {
+    it('defaults to Valkey in values and in the template', () => {
+        expect(values.redis.internal.image).toMatch(/^valkey\/valkey:/)
+        expect(redis).toContain('default "valkey/valkey:8-alpine"')
+    })
+
+    it('invokes it through the redis-server name both images provide', () => {
+        // Valkey ships redis-server as a symlink, so redis.internal.image can
+        // be set back to a Redis image without touching anything else. A
+        // valkey-specific command would quietly break that.
+        expect(redis).toContain('- redis-server')
+        expect(redis).not.toContain('valkey-server')
+    })
+
+    it('tests against the same store the chart bundles', () => {
+        // Integration and e2e run on whatever this says; if it drifts from the
+        // chart, CI stops covering what installations actually run.
+        expect(compose.services.redis.image).toBe(values.redis.internal.image)
+        expect(workflow.jobs.integration.services.redis.image).toBe(values.redis.internal.image)
+    })
+
+    it('keeps the redis-cli health check, which Valkey also provides', () => {
+        expect(workflow.jobs.integration.services.redis.options).toContain('redis-cli ping')
+    })
+})


### PR DESCRIPTION
## Why

`redis:7-alpine` resolves to **Redis 7.4.8**, and 7.4 is the first line under RSALv2/SSPLv1 rather than BSD — verified by pulling the tag, not from memory. So the default install of an open-source chart has been shipping a component that is not open source. Valkey is BSD-3, under the Linux Foundation, and is the drop-in the ecosystem settled on.

## What changes: the image, and nothing else

| | before | after |
|---|---|---|
| `values.yaml` / `redis.yaml` default | `redis:7-alpine` | `valkey/valkey:8-alpine` |
| `docker-compose.test.yml` (integration + e2e) | `redis:7-alpine` | `valkey/valkey:8-alpine` |
| CI integration service container | `redis:7-alpine` | `valkey/valkey:8-alpine` |

The container command stays `redis-server` and the CI health check stays `redis-cli ping`, because the Valkey image ships both as symlinks. That image dispatches on `argv[0]` (`valkey-check-rdb` is a symlink to `valkey-server`), so I checked the symlinks actually work rather than assuming:

```
$ docker run --entrypoint redis-server valkey/valkey:8-alpine --version
Valkey server v=8.1.10 …
$ docker exec … redis-cli ping
PONG
$ docker exec … redis-cli info server
redis_version:7.2.4      # what it advertises to clients that sniff
server_name:valkey
valkey_version:8.1.10
```

Keeping those names is the point: `redis.internal.image` can be set back to `redis:7-alpine` or `redis:8-alpine` with no other edit. A `valkey-server` command would have quietly broken that, so a test asserts it stays.

## Evidence it works

The adapter uses only core commands — `scan`, `multi`, `expire`, `rpush`, `set`, `get`, `del`, `hset` — and nothing from the Redis modules, so there was no reason to expect trouble. The evidence rather than the expectation: **the full integration suite passes unchanged against Valkey 8.1.10**, 12 files / 57 tests, every OIDC flow going through the real store. I also brought up the whole compose stack (Valkey + Dex) on the new file.

## Why the test-side switch matters as much

If the tests kept running on Redis while the chart bundled Valkey, CI would stop covering what installations actually run. `test/unit/chart-session-store.test.js` ties the three together — chart default, compose, CI service — so they cannot drift apart, plus the `redis-server`/`redis-cli` interchangeability above.

## Upgrade safety

The bundled store is explicitly non-persistent (`values.yaml` says so; the compose file runs `--save "" --appendonly no`), so sessions already do not survive a restart and this is a rollout, not a data migration. `redisClaim` and `redis.external` are untouched. `docs/migrating-to-2.0.md` keeps naming `redis:7-alpine` because it records what 2.0 did.

Worth a line in the 2.4.0 release notes as a default change: anyone who pinned `redis.internal.image` is unaffected, anyone on the default gets a different binary.

Suites: unit 71 files / 373 tests, integration 12 / 57. `helm lint` clean, rendered both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)