### PR TITLE
feat: read a client's host from an Ingress with spec.ingressRef (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,12 +324,12 @@ spec:
 Both `labels` and `annotations` are optional and are reconciled onto the secret
 on every change to the `OIDCClient`.
 
-### Enrolling from Ingress annotations
+### Ingress integration
 
-An application that already declares its hostname and path in an `Ingress` can
-be enrolled from `codemowers.io/oidc-*` annotations on it instead of a
-hand-written `OIDCClient` — Passmower derives the client, owned by that Ingress,
-and reconciles it as usual. Off by default; see
+An application that already declares its hostname in an `Ingress` need not
+repeat it: `codemowers.io/oidc-*` annotations on the Ingress derive the whole
+client, or a hand-written `OIDCClient` can read the host from one with
+`spec.ingressRef`. Off by default; see
 [docs/ingress-discovery.md](docs/ingress-discovery.md).
 
 ## Listing a user's applications

--- a/charts/passmower/templates/crds.yaml
+++ b/charts/passmower/templates/crds.yaml
@@ -778,9 +778,11 @@ spec:
             spec:
               type: object
               required:
-                - redirectUris
                 - grantTypes
                 - responseTypes
+              x-kubernetes-validations:
+                - rule: "has(self.redirectUris) != (has(self.ingressRef) && has(self.redirectPaths))"
+                  message: "set either redirectUris, or ingressRef with redirectPaths — not both and not neither"
               properties:
                 allowedCORSOrigins:
                   type: array
@@ -889,6 +891,26 @@ spec:
                   type: array
                   items:
                     type: string
+                ingressRef:
+                  type: object
+                  description: >-
+                    Take the host from an Ingress in this namespace instead of
+                    repeating it here. uri and redirectUris are then resolved
+                    from that host plus redirectPaths, and are never written
+                    back to this resource. Requires
+                    passmower.ingressDiscovery.enabled. Same namespace only:
+                    referencing another namespace's Ingress would let a client
+                    claim a hostname it does not own.
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                redirectPaths:
+                  type: array
+                  description: Paths resolved against the ingressRef host into redirectUris, e.g. /login/generic_oauth.
+                  items:
+                    type: string
                 responseTypes:
                   type: array
                   items:
@@ -944,6 +966,17 @@ spec:
                   type: string
                   format: date-time
                   description: Latest successful authorization or token exchange.
+                resolvedUri:
+                  type: string
+                  description: >-
+                    The uri an ingressRef resolved to. Reported rather than
+                    written into spec, so the resource stays as its author
+                    wrote it.
+                resolvedRedirectUris:
+                  type: array
+                  description: The redirectUris an ingressRef plus redirectPaths resolved to.
+                  items:
+                    type: string
       subresources: &oidcClientSubresources
         status: {}
       additionalPrinterColumns: &oidcClientPrinterColumns

--- a/docs/ingress-discovery.md
+++ b/docs/ingress-discovery.md
@@ -1,9 +1,14 @@
-# Enrolling applications from Ingress annotations
+# Ingress integration
 
-Applications are normally enrolled by writing an `OIDCClient`. Passmower can
-also derive one from annotations on an `Ingress`, the way Traefik and
-external-dns are configured, so an application that already declares its
-hostname and path in an Ingress does not have to repeat them.
+An application that already declares its hostname in an `Ingress` should not
+have to repeat it in its `OIDCClient`. There are two ways not to, both off
+unless `passmower.ingressDiscovery.enabled` is set:
+
+- **[Annotations on the Ingress](#annotating-an-ingress)** derive the whole
+  client, the way Traefik and external-dns are configured — no `OIDCClient` to
+  write at all.
+- **[`ingressRef` on the OIDCClient](#taking-the-host-from-an-ingress-ingressref)**
+  keeps the client hand-written but reads the host from an Ingress.
 
 Off by default, because it creates resources and needs cluster read on
 Ingresses, which the chart grants only when it is on:
@@ -118,10 +123,77 @@ Events:
 | `OIDCClientConflict` | a client of that name exists and is not ours to manage |
 | `IngressDiscoveryFailed` | the annotations do not describe a client — the message says why |
 
+## Taking the host from an Ingress (`ingressRef`)
+
+The other direction: keep writing the `OIDCClient` by hand, but read the host
+from an Ingress instead of repeating it.
+
+```yaml
+apiVersion: codemowers.cloud/v1
+kind: OIDCClient
+metadata:
+  name: grafana
+  namespace: apps
+spec:
+  displayName: Grafana
+  grantTypes: ['authorization_code']
+  responseTypes: ['code']
+  availableScopes: ['openid', 'profile', 'email']
+  ingressRef:
+    name: grafana
+  redirectPaths:
+    - /login/generic_oauth
+```
+
+`uri` and `redirectUris` are resolved from the referenced Ingress' host plus
+`redirectPaths`, and are **not written back into the resource** — the operator
+reports them in status instead, so a GitOps tool sees no drift on a resource it
+owns:
+
+```console
+$ kubectl -n apps get oidcclient grafana -o jsonpath='{.status.resolvedUri}'
+https://grafana.example.com/
+```
+
+Set either `redirectUris` **or** `ingressRef` with `redirectPaths` — the CRD
+rejects both together and neither at all:
+
+```
+The OIDCClient "grafana" is invalid: spec: Invalid value: set either
+redirectUris, or ingressRef with redirectPaths — not both and not neither
+```
+
+Rules, mostly the same as for annotation discovery:
+
+- **Same namespace only.** `ingressRef` has no `namespace` field, deliberately:
+  pointing at another namespace's Ingress would let a client claim a hostname it
+  does not own.
+- **One host**, for the same reason discovery refuses several.
+- **Requires `passmower.ingressDiscovery.enabled`**, which is what grants Ingress
+  read. Without it the client reports
+  `Ready=False IngressRefUnresolved` naming the setting.
+- **A missing or unusable Ingress is refused, not guessed at**: registering a
+  client with no redirect URI would fail logins with a mismatch, which is much
+  harder to place than a condition saying `the referenced Ingress does not
+  exist`.
+- **A renamed host takes effect immediately.** Renaming the Ingress host does not
+  touch the client, so nothing about the client changes and its reconcile
+  fingerprint is unmoved; the Ingress watch asks the client operator to
+  reconcile it anyway, and the resolved values follow within a second.
+
+> **All Passmower instances watching the namespace must be 2.4.0 or newer.**
+> `ingressRef` clients have no `spec.redirectUris`, and an older instance
+> requires that field — it fails their reconcile with
+> `Ready=False ReconcileFailed: Cannot read properties of undefined (reading
+> 'join')`. This matters where two instances watch the same namespaces (see
+> `NAMESPACE_SELECTOR`): upgrade them together, or the older one will keep
+> claiming such clients and failing them.
+
 ## When to write the OIDCClient instead
 
-Discovery covers the common shape: one host, one or more redirect paths, group
-or user allowlists. Anything else — `secretRefreshJobSpec`, `claimMappings`,
+Annotation discovery covers the common shape: one host, one or more redirect
+paths, group or user allowlists — and `ingressRef` covers the case where the
+client is hand-written but its host should not be duplicated. Anything else — `secretRefreshJobSpec`, `claimMappings`,
 `allowedCORSOrigins`, `pkce`, `displayOrder`, a client whose redirect URI is not
 on its own Ingress host, or a native application with a custom-scheme redirect —
 is a reason to write the `OIDCClient` directly. The two can coexist in one

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ import {validateGroupConfiguration} from './utils/group-configuration.js';
 import {getActivityTracker} from './services/activity-tracker.js';
 import KubeOidcUserEventHookOperator from './operators/kube-oidc-user-event-hook-operator.js';
 import {KubeIngressDiscoveryOperator} from "./operators/kube-ingress-discovery-operator.js";
+import {KubernetesAdapter} from "./adapters/kubernetes.js";
 
 const __dirname = dirname(import.meta.url);
 
@@ -64,7 +65,10 @@ export async function startOperators(provider) {
     // Opt-in: discovery creates OIDCClient resources from annotations on any
     // Ingress it can read, so an installation says when it wants that.
     if (process.env.INGRESS_DISCOVERY_ENABLED === 'true') {
-        const ingressDiscoveryOperator = new KubeIngressDiscoveryOperator()
+        // The client operator goes along so a changed Ingress host reaches the
+        // clients that resolve theirs from it (spec.ingressRef).
+        const ingressDiscoveryOperator = new KubeIngressDiscoveryOperator(
+            new KubernetesAdapter(), kubeClientOperator)
         await ingressDiscoveryOperator.watchIngresses()
     }
     activityTracker.start()

--- a/src/models/oidc-client.js
+++ b/src/models/oidc-client.js
@@ -34,6 +34,8 @@ class OIDCClient {
     #idTokenSignedResponseAlg = null
     #applicationType = null
     #redirectUris = null
+    #ingressRef = null
+    #redirectPaths = null
     #allowedGroups = null
     #allowedUsers = null
     #claimMappings = null
@@ -92,7 +94,11 @@ class OIDCClient {
         this.#tokenEndpointAuthMethod = incomingClient.spec.tokenEndpointAuthMethod || configuration.clientDefaults.token_endpoint_auth_method
         this.#idTokenSignedResponseAlg = incomingClient.spec.idTokenSignedResponseAlg || configuration.clientDefaults.id_token_signed_response_alg
         this.#applicationType = incomingClient.spec.applicationType || configuration.clientDefaults.application_type
-        this.#redirectUris = incomingClient.spec.redirectUris
+        // Absent when the client takes its host from an Ingress; the operator
+        // resolves it before anything reads it.
+        this.#redirectUris = incomingClient.spec.redirectUris ?? []
+        this.#ingressRef = incomingClient.spec.ingressRef ?? null
+        this.#redirectPaths = incomingClient.spec.redirectPaths ?? []
         this.#allowedGroups = incomingClient.spec.allowedGroups || []
         this.#allowedUsers = incomingClient.spec.allowedUsers || []
         this.#claimMappings = incomingClient.spec.claimMappings ?? {}
@@ -147,6 +153,31 @@ class OIDCClient {
             ],
             ...this.#secretMetadata
         }
+    }
+
+    getIngressRef() {
+        return this.#ingressRef
+    }
+
+    getRedirectPaths() {
+        return this.#redirectPaths
+    }
+
+    getRedirectUris() {
+        return this.#redirectUris
+    }
+
+    getUri() {
+        return this.#uri
+    }
+
+    // The result of resolving spec.ingressRef against the Ingress host. Applied
+    // in memory only: writing it into spec would make the operator fight
+    // whatever wrote the resource, which for a hand-written client is Git.
+    setResolvedIngress({uri, redirectUris}) {
+        this.#uri = uri
+        this.#redirectUris = redirectUris
+        return this
     }
 
     getClaimMappings() {
@@ -218,7 +249,17 @@ class OIDCClient {
     }
 
     getIntendedStatus() {
-        return this.#activityState.getIntendedStatus()
+        const status = this.#activityState.getIntendedStatus()
+        if (!this.#ingressRef?.name) {
+            return status
+        }
+        // What the reference resolved to, reported rather than written into
+        // spec — the only place an operator gets to say what it derived.
+        return {
+            ...status,
+            resolvedUri: this.#uri ?? null,
+            resolvedRedirectUris: this.#redirectUris ?? [],
+        }
     }
 
     updateActivityCondition(now, inactiveAfterDays) {

--- a/src/operators/kube-ingress-discovery-operator.js
+++ b/src/operators/kube-ingress-discovery-operator.js
@@ -22,8 +22,13 @@ import {
 // operator can inspect for what was discovered, and no orphan to clean up when
 // the Ingress goes away, because ownerReferences collect it.
 export class KubeIngressDiscoveryOperator {
-    constructor(adapter = new KubernetesAdapter()) {
+    // `clientOperator` is optional: without it, discovery still creates and
+    // withdraws clients, and a client whose spec.ingressRef points at a changed
+    // Ingress simply waits for its next reconcile rather than being asked for
+    // one immediately.
+    constructor(adapter = new KubernetesAdapter(), clientOperator = undefined) {
         this.adapter = adapter
+        this.clientOperator = clientOperator
         this.namespaceFilter = new NamespaceFilter(this.adapter.namespace)
     }
 
@@ -49,6 +54,7 @@ export class KubeIngressDiscoveryOperator {
         if (!namespace || !name) {
             return
         }
+        await this.#reconcileReferencingClients(ingress)
         try {
             const existing = await this.adapter.getNamespacedCustomObject(
                 OIDCClientCrd, namespace, name, (client) => client)
@@ -137,6 +143,31 @@ export class KubeIngressDiscoveryOperator {
         }
         await this.#event(ingress, 'OIDCClientDiscovered',
             `Updated OIDCClient ${name} for ${spec.uri}`, 'Normal')
+    }
+
+    // A client with spec.ingressRef resolves its host from this Ingress, and a
+    // changed host does not touch the client, so nothing else would ask it to
+    // reconcile: its generation is unmoved and the operator's fingerprint check
+    // skips it. Waiting for the next watch re-list would leave the client
+    // registered with a stale redirect URI in the meantime, which fails logins
+    // with a mismatch.
+    async #reconcileReferencingClients(ingress) {
+        if (!this.clientOperator) {
+            return
+        }
+        const {namespace, name} = ingress.metadata
+        try {
+            const clients = await this.adapter.listNamespacedCustomObject(
+                OIDCClientCrd, namespace, (client) => client)
+            const referencing = (clients ?? [])
+                .filter(client => client?.spec?.ingressRef?.name === name)
+            for (const client of referencing) {
+                await this.clientOperator.reconcileClientByName(namespace, client.metadata.name)
+            }
+        } catch (error) {
+            globalThis.logger?.error({error, ingress: `${namespace}/${name}`},
+                'Failed to reconcile clients referencing an Ingress')
+        }
     }
 
     // Events land on the Ingress, which is where somebody who wrote an

--- a/src/operators/kube-oidc-client-operator.js
+++ b/src/operators/kube-oidc-client-operator.js
@@ -1,5 +1,8 @@
 import OidcClient from "../models/oidc-client.js";
 import {
+    IngressApiGroup,
+    IngressApiGroupVersion,
+    IngressCrd,
     OIDCClientCrd,
     OIDCClientSecretClientSecretKey
 } from "../utils/kubernetes/kube-constants.js";
@@ -9,6 +12,7 @@ import {NamespaceFilter} from "../utils/kubernetes/namespace-filter.js";
 import {getActivityTracker} from "../services/activity-tracker.js";
 import {ClientReconcileState} from '../models/client-activity-state.js';
 import {validateClaimMappings} from '../utils/claim-mappings.js'
+import {resolveIngressRef} from '../utils/kubernetes/resolve-ingress-ref.js'
 
 export class KubeOIDCClientOperator {
     constructor(provider, adapter = new KubernetesAdapter(), redisAdapter = new RedisAdapter('Client')) {
@@ -36,6 +40,7 @@ export class KubeOIDCClientOperator {
         try {
             this.#assertValidClaimMappings(OIDCClient)
             if (OIDCClient.getInstance() === this.instance) {
+                await this.#resolveIngressRef(OIDCClient)
                 if (!await this.redisAdapter.find(OIDCClient.getClientId())) {
                     await this.#reconcileClientSecret(OIDCClient)
                 }
@@ -45,6 +50,10 @@ export class KubeOIDCClientOperator {
                 const claimedClient = await this.#replaceClientStatus(OIDCClient)
                 if (claimedClient?.getInstance() === this.instance) {
                     OIDCClient = claimedClient
+                    // After the claim, not before: claiming rebuilds the model
+                    // from the stored resource, and the resolution is in-memory
+                    // only, so resolving first would be discarded here.
+                    await this.#resolveIngressRef(OIDCClient)
                     await this.#reconcileClientSecret(OIDCClient)
                 } else {
                     return
@@ -78,8 +87,8 @@ export class KubeOIDCClientOperator {
         )
     }
 
-    async #updateOIDCClient(OIDCClient) {
-        if (!this.reconcileState.shouldReconcile(OIDCClient)) return
+    async #updateOIDCClient(OIDCClient, {force = false} = {}) {
+        if (!this.reconcileState.shouldReconcile(OIDCClient) && !force) return
         if (OIDCClient.getInstance() !== this.instance) {
             if (OIDCClient.getInstance()) return
             const claimedClient = await this.#replaceClientStatus(OIDCClient)
@@ -88,6 +97,7 @@ export class KubeOIDCClientOperator {
         }
         try {
             this.#assertValidClaimMappings(OIDCClient)
+            await this.#resolveIngressRef(OIDCClient)
             if (OIDCClient.isDisabled()) {
                 await this.redisAdapter.destroy(OIDCClient.getClientId())
                 await this.#reportReady(OIDCClient, 'Disabled', 'Client is disabled and absent from Redis')
@@ -190,6 +200,53 @@ export class KubeOIDCClientOperator {
                 `Invalid spec.claimMappings: ${problems.join('; ')}`
             )
         }
+    }
+
+    // A client with spec.ingressRef takes its host from an Ingress in its own
+    // namespace. Resolved on every reconcile and applied in memory, so nothing
+    // is written back into a resource its author owns, and a changed host is
+    // picked up the next time the client is reconciled — which the Ingress
+    // watch asks for as soon as it sees one (#35).
+    async #resolveIngressRef(OIDCClient) {
+        const ingressRef = OIDCClient.getIngressRef()
+        if (!ingressRef?.name) {
+            return
+        }
+        if (process.env.INGRESS_DISCOVERY_ENABLED !== 'true') {
+            throw this.#reconcileError('IngressRefUnresolved',
+                'spec.ingressRef needs Ingress access: set passmower.ingressDiscovery.enabled')
+        }
+        const ingress = await this.adapter.getNamespacedCustomObject(
+            IngressCrd,
+            OIDCClient.getClientNamespace(),
+            ingressRef.name,
+            (obj) => obj,
+            IngressApiGroup,
+            IngressApiGroupVersion,
+        )
+        const {uri, redirectUris, problems} = resolveIngressRef(ingress, OIDCClient.getRedirectPaths())
+        if (problems) {
+            // Registering the client with no redirect URI would fail logins with
+            // a mismatch instead; say so on the resource.
+            throw this.#reconcileError('IngressRefUnresolved',
+                `Cannot resolve spec.ingressRef ${ingressRef.name}: ${problems.join('; ')}`)
+        }
+        OIDCClient.setResolvedIngress({uri, redirectUris})
+    }
+
+    // Reconcile one client by name whatever its reconcile fingerprint says.
+    // A changed Ingress host changes what a client resolves to without touching
+    // the client itself, so its generation does not move and the usual
+    // fingerprint check would skip it.
+    async reconcileClientByName(namespace, name) {
+        const client = await this.adapter.getNamespacedCustomObject(
+            OIDCClientCrd, namespace, name,
+            (incoming) => (new OidcClient()).fromIncomingClient(incoming))
+        if (!client) {
+            return false
+        }
+        await this.#updateOIDCClient(client, {force: true})
+        return true
     }
 
     async #reportReady(OIDCClient, reason, message) {

--- a/src/utils/kubernetes/resolve-ingress-ref.js
+++ b/src/utils/kubernetes/resolve-ingress-ref.js
@@ -1,0 +1,32 @@
+import {hostsOf} from './ingress-oidc-client.js'
+
+// spec.ingressRef lets a hand-written OIDCClient take its host from an Ingress
+// rather than repeat it (#35). Resolution is pure and the result is applied in
+// memory: uri and redirectUris are never written back into spec, so the
+// resource stays exactly as its author — usually Git — wrote it.
+//
+// Same namespace only, enforced by the CRD having no namespace field: pointing
+// at another namespace's Ingress would let a client claim a hostname it does
+// not own.
+export const resolveIngressRef = (ingress, redirectPaths = []) => {
+    if (!ingress) {
+        return {problems: ['the referenced Ingress does not exist']}
+    }
+    const hosts = hostsOf(ingress)
+    if (!hosts.length) {
+        return {problems: ['the referenced Ingress has no host in spec.rules']}
+    }
+    if (hosts.length > 1) {
+        // Same reason discovery refuses it: which host an application
+        // authenticates on is not a good thing to guess at.
+        return {problems: [`the referenced Ingress has ${hosts.length} hosts (${hosts.join(', ')})`]}
+    }
+    if (!redirectPaths.length) {
+        return {problems: ['spec.redirectPaths is empty, so no redirect URI can be built']}
+    }
+    const host = hosts[0]
+    return {
+        uri: `https://${host}/`,
+        redirectUris: redirectPaths.map(path => new URL(path, `https://${host}`).href),
+    }
+}

--- a/test/unit/client-secret-convergence.test.js
+++ b/test/unit/client-secret-convergence.test.js
@@ -153,6 +153,27 @@ describe('secret-refresh Job under overlapping reconciles', () => {
     })
 
     it('treats an already-created Job as done, not as a failure', async () => {
+        // A Job already carrying this client's resourceVersion means another
+        // reconcile of the same version created it. Reporting that from the
+        // adapter tests the behaviour directly — and fails if the operator
+        // stops asking for ignoreAlreadyExists, since then the create reads as
+        // an error.
+        let asked
+        adapter.createJob = async (_namespace, _job, {ignoreAlreadyExists = false} = {}) => {
+            asked = ignoreAlreadyExists
+            return ignoreAlreadyExists ? {alreadyExists: true} : null
+        }
+        adapter.seed('OIDCClient', oidcClient('grafana', {refreshJob: true}))
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        expect(asked).toBe(true)
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'True', reason: 'Reconciled'}))
+        expect(adapter.events.filter(e => e.type === 'Warning')).toEqual([])
+    })
+
+    it('creates no two Jobs of the same name when reconciles overlap', async () => {
         adapter.seed('OIDCClient', oidcClient('grafana', {refreshJob: true}))
 
         await Promise.all([
@@ -160,9 +181,11 @@ describe('secret-refresh Job under overlapping reconciles', () => {
             adapter.fireWatch('ADDED', 'OIDCClient', 'grafana'),
         ])
 
-        // The name is derived from the resourceVersion, so the second create is
-        // the same Job — one Job, and no spurious Warning on a healthy client.
-        expect(adapter.jobs).toHaveLength(1)
+        // Each reconcile claims the client and so sees its own resourceVersion,
+        // which is one Job per version by design; what must not happen is two
+        // creates of the same name, or a healthy client reporting a failure.
+        const names = adapter.jobs.map(job => job.jobManifest.metadata.name)
+        expect(new Set(names).size).toBe(names.length)
         expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
             expect.objectContaining({type: 'Ready', status: 'True', reason: 'Reconciled'}))
         expect(adapter.events.filter(e => e.type === 'Warning')).toEqual([])

--- a/test/unit/ingress-ref.test.js
+++ b/test/unit/ingress-ref.test.js
@@ -1,0 +1,202 @@
+import {readFileSync} from 'node:fs'
+import {load, loadAll} from 'js-yaml'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {FakeKubernetesAdapter} from '../fakes/fake-kubernetes-adapter.js'
+import {KubeOIDCClientOperator} from '../../src/operators/kube-oidc-client-operator.js'
+import {KubeIngressDiscoveryOperator} from '../../src/operators/kube-ingress-discovery-operator.js'
+import {resolveIngressRef} from '../../src/utils/kubernetes/resolve-ingress-ref.js'
+
+class FakeRedisAdapter {
+    records = new Map()
+
+    async find(id) { return this.records.get(id) }
+    async upsert(id, value) { this.records.set(id, value) }
+    async destroy(id) { this.records.delete(id) }
+}
+
+const ingress = (host = 'grafana.example.com', name = 'grafana') => ({
+    metadata: {name, namespace: 'apps', uid: `uid-${name}`},
+    spec: {rules: [].concat(host).map(h => ({host: h}))},
+})
+
+const clientWithRef = (name = 'grafana', {ingressName = 'grafana', paths = ['/login/generic_oauth']} = {}) => ({
+    metadata: {name, namespace: 'apps', generation: 1, uid: `uid-${name}`, resourceVersion: '1'},
+    spec: {
+        grantTypes: ['authorization_code'], responseTypes: ['code'],
+        availableScopes: ['openid'],
+        ingressRef: {name: ingressName},
+        redirectPaths: paths,
+    },
+    status: {},
+})
+
+describe('resolving an ingressRef', () => {
+    it('builds the uri and redirect URIs from the host', () => {
+        expect(resolveIngressRef(ingress(), ['/login/generic_oauth', '/other'])).toEqual({
+            uri: 'https://grafana.example.com/',
+            redirectUris: [
+                'https://grafana.example.com/login/generic_oauth',
+                'https://grafana.example.com/other',
+            ],
+        })
+    })
+
+    it('says what it could not resolve rather than returning something empty', () => {
+        expect(resolveIngressRef(undefined, ['/cb']).problems)
+            .toEqual(['the referenced Ingress does not exist'])
+        expect(resolveIngressRef({spec: {rules: []}}, ['/cb']).problems)
+            .toEqual(['the referenced Ingress has no host in spec.rules'])
+        expect(resolveIngressRef(ingress(), []).problems)
+            .toEqual(['spec.redirectPaths is empty, so no redirect URI can be built'])
+        expect(resolveIngressRef(ingress(['a.example.com', 'b.example.com']), ['/cb']).problems[0])
+            .toMatch(/has 2 hosts/)
+    })
+})
+
+describe('a client that takes its host from an Ingress', () => {
+    let adapter, redis, operator
+
+    beforeEach(async () => {
+        vi.stubEnv('INGRESS_DISCOVERY_ENABLED', 'true')
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.deployment = 'passmower'
+        redis = new FakeRedisAdapter()
+        operator = new KubeOIDCClientOperator(
+            {urlFor: endpoint => `https://id.example.com/${endpoint}`}, adapter, redis)
+        await operator.watchClients()
+    })
+    afterEach(() => vi.unstubAllEnvs())
+
+    it('registers the resolved redirect URI', async () => {
+        adapter.seed('Ingress', ingress())
+        adapter.seed('OIDCClient', clientWithRef())
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        const record = redis.records.get('apps.grafana')
+        expect(record.redirect_uris).toEqual(['https://grafana.example.com/login/generic_oauth'])
+        expect(record.uri).toBe('https://grafana.example.com/')
+    })
+
+    it('reports what it resolved to in status, and leaves spec alone', async () => {
+        adapter.seed('Ingress', ingress())
+        adapter.seed('OIDCClient', clientWithRef())
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        const stored = adapter.list('OIDCClient')[0]
+        expect(stored.status.resolvedUri).toBe('https://grafana.example.com/')
+        expect(stored.status.resolvedRedirectUris)
+            .toEqual(['https://grafana.example.com/login/generic_oauth'])
+        // Writing the resolution into spec would make the operator fight
+        // whatever wrote the resource, which for a hand-written client is Git.
+        expect(stored.spec.uri).toBeUndefined()
+        expect(stored.spec.redirectUris).toBeUndefined()
+    })
+
+    it('refuses to register a client whose Ingress is missing', async () => {
+        adapter.seed('OIDCClient', clientWithRef())
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        // A client registered with no redirect URI would fail logins with a
+        // mismatch, which is harder to place than a condition saying this.
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({type: 'Ready', status: 'False', reason: 'IngressRefUnresolved'}))
+        expect(redis.records.size).toBe(0)
+    })
+
+    it('says so when Ingress access is not enabled', async () => {
+        vi.stubEnv('INGRESS_DISCOVERY_ENABLED', 'false')
+        adapter.seed('Ingress', ingress())
+        adapter.seed('OIDCClient', clientWithRef())
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+
+        expect(adapter.list('OIDCClient')[0].status.conditions).toContainEqual(
+            expect.objectContaining({
+                type: 'Ready', status: 'False', reason: 'IngressRefUnresolved',
+                message: expect.stringContaining('passmower.ingressDiscovery.enabled'),
+            }))
+    })
+
+    it('leaves a client with its own redirectUris untouched', async () => {
+        adapter.seed('OIDCClient', {
+            metadata: {name: 'plain', namespace: 'apps', generation: 1, uid: 'u', resourceVersion: '1'},
+            spec: {grantTypes: ['authorization_code'], responseTypes: ['code'],
+                availableScopes: ['openid'], redirectUris: ['https://plain.example.com/cb']},
+            status: {},
+        })
+
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'plain')
+
+        expect(redis.records.get('apps.plain').redirect_uris)
+            .toEqual(['https://plain.example.com/cb'])
+        expect(adapter.list('OIDCClient')[0].status.resolvedUri).toBeUndefined()
+    })
+})
+
+describe('a changed Ingress host', () => {
+    it('is picked up by the clients that resolve theirs from it', async () => {
+        vi.stubEnv('INGRESS_DISCOVERY_ENABLED', 'true')
+        globalThis.logger = {debug() {}, info() {}, warn() {}, error() {}, trace() {}}
+        const adapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        adapter.deployment = 'passmower'
+        const redis = new FakeRedisAdapter()
+        const clientOperator = new KubeOIDCClientOperator(
+            {urlFor: endpoint => `https://id.example.com/${endpoint}`}, adapter, redis)
+        await clientOperator.watchClients()
+        adapter.seed('Ingress', ingress())
+        adapter.seed('OIDCClient', clientWithRef())
+        await adapter.fireWatch('ADDED', 'OIDCClient', 'grafana')
+        expect(redis.records.get('apps.grafana').redirect_uris)
+            .toEqual(['https://grafana.example.com/login/generic_oauth'])
+
+        // A separate adapter, as the discovery operator gets in app.js: one
+        // watch per adapter.
+        const discoveryAdapter = new FakeKubernetesAdapter({namespace: 'apps', instance: 'test-passmower'})
+        discoveryAdapter.store = adapter.store
+        const discovery = new KubeIngressDiscoveryOperator(discoveryAdapter, clientOperator)
+        await discovery.watchIngresses()
+
+        // Renaming the host does not touch the client, so its generation does
+        // not move and the operator's own fingerprint check would skip it.
+        adapter.seed('Ingress', ingress('renamed.example.com'))
+        await discoveryAdapter.fireWatch('MODIFIED', 'Ingress', 'grafana')
+
+        expect(redis.records.get('apps.grafana').redirect_uris)
+            .toEqual(['https://renamed.example.com/login/generic_oauth'])
+        expect(adapter.list('OIDCClient')[0].status.resolvedUri).toBe('https://renamed.example.com/')
+        vi.unstubAllEnvs()
+    })
+})
+
+describe('the CRD for ingressRef', () => {
+    const crd = loadAll(readFileSync(
+        new URL('../../charts/passmower/templates/crds.yaml', import.meta.url), 'utf8'))
+        .find(doc => doc?.metadata?.name === 'oidcclients.codemowers.cloud')
+
+    it.each(crd.spec.versions.map(version => version.name))('declares it on %s', (versionName) => {
+        const schema = crd.spec.versions.find(v => v.name === versionName)
+            .schema.openAPIV3Schema.properties.spec
+
+        expect(schema.properties.ingressRef.required).toEqual(['name'])
+        // No namespace field, deliberately: pointing at another namespace's
+        // Ingress would let a client claim a hostname it does not own.
+        expect(Object.keys(schema.properties.ingressRef.properties)).toEqual(['name'])
+        expect(schema.properties.redirectPaths.items.type).toBe('string')
+        // redirectUris can no longer be required outright, so a CEL rule keeps
+        // one of the two forms mandatory.
+        expect(schema.required).not.toContain('redirectUris')
+        expect(schema['x-kubernetes-validations'][0].rule)
+            .toBe('has(self.redirectUris) != (has(self.ingressRef) && has(self.redirectPaths))')
+    })
+
+    it('keeps the chart values documenting that this needs Ingress access', () => {
+        const values = load(readFileSync(
+            new URL('../../charts/passmower/values.yaml', import.meta.url), 'utf8'))
+
+        expect(values.passmower.ingressDiscovery.enabled).toBe(false)
+    })
+})


### PR DESCRIPTION
Closes #35 — the `ingressRef` half, after #247 did the annotations. Needs closing by hand (PRs into `develop` don't auto-close).

## Shape

Keep writing the `OIDCClient`, but take its host from an Ingress:

```yaml
spec:
  grantTypes: ['authorization_code']
  responseTypes: ['code']
  ingressRef:
    name: grafana
  redirectPaths:
    - /login/generic_oauth
```

`uri` and `redirectUris` resolve from that Ingress' host, and are **reported in status, never written back into spec** — writing them there would make the operator fight whatever wrote the resource, which for a hand-written client is Git. Status is the one place an operator gets to say what it derived:

```console
$ kubectl get oidcclient grafana -o jsonpath='{.status.resolvedUri}'
https://grafana.example.com/
```

## Two decisions with reasoning

**Resolution lives in the client operator**, so a new client resolves on its first reconcile. But a renamed Ingress host doesn't touch the client — its `generation` is unmoved, and the reconcile fingerprint is `{generation, description}`, so the operator's own check would skip it. That's why the Ingress watch now asks the client operator to reconcile clients referencing that Ingress, and why the discovery operator takes one. Leaving it to the next watch re-list would keep a stale redirect URI registered for up to an hour, failing logins with a mismatch.

**No `namespace` field on `ingressRef`**, deliberately: pointing at another namespace's Ingress would let a client claim a hostname it does not own.

`redirectUris` can no longer be required outright, so a CEL rule keeps one of the two forms mandatory:

```
has(self.redirectUris) != (has(self.ingressRef) && has(self.redirectPaths))
```

## Verified on minikube

Against a real API server, with the client operator and Ingress watch actually running:

| | result |
|---|---|
| CEL: `ingressRef` + `redirectPaths` | accepted |
| CEL: plain `redirectUris` | accepted |
| CEL: both together / neither / `ingressRef` without paths | all three rejected with that message |
| client created | `Ready=True`, `status.resolvedUri=https://grafana.ref.example.com/`, and **Redis carries the resolved `redirect_uris`** — so the provider will actually accept that URI |
| spec afterwards | still exactly as written: no `uri`, no `redirectUris` |
| Ingress host renamed | resolved values and the Redis record both followed within seconds, without the client being touched |
| Ingress deleted | `Ready=False IngressRefUnresolved: the referenced Ingress does not exist` — refused rather than registered with no redirect URI |

## A compatibility finding worth reading

While testing, your in-cluster `passmower-dev` (which runs `NAMESPACE_SELECTOR=*`) claimed my test client and failed it with `Cannot read properties of undefined (reading 'join')`. That is **an older Passmower meeting an `ingressRef` client**: such clients have no `spec.redirectUris`, and versions before this one require it. The new code defaults it, so this only affects instances that haven't been upgraded.

It's documented as a warning in `docs/ingress-discovery.md`: all instances watching the namespace must be 2.4.0 or newer, which matters exactly where two instances share namespaces. Worth a release note too.

## One existing test changed

`client-secret-convergence`'s "already-created Job" case asserted that two racing reconciles create exactly one refresh Job. That held only by interleaving: each reconcile claims the client and so sees its own `resourceVersion`, which is one Job per version by design, and the extra `await` this PR adds shifted the timing enough to expose it. It now reports `alreadyExists` from the adapter — testing that a duplicate create reads as success, and failing if the operator stops passing `ignoreAlreadyExists` — plus a separate case asserting no two Jobs share a name. Product behaviour unchanged; the old assertion was pinning an accident.

Suites: unit 72 files / 385 tests, integration 12 / 57. `helm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)